### PR TITLE
chore: rename extension id to depsy-lsp (v2.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-08-28
+
+### Changed
+
+- The Zed extension id is `depsy-lsp` instead of `depsy`: Zed's
+  [publishing prerequisites](https://zed.dev/docs/extensions/publishing/prerequisites)
+  require language-server-only extensions to carry an `-lsp` or
+  `-language-server` suffix. The extension name stays "Depsy" and the
+  settings key stays `lsp.depsy`.
+
 ## [2.0.0] - 2026-08-28
 
 ### Changed
@@ -810,7 +820,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-depsy/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/mpiton/zed-depsy/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/mpiton/zed-depsy/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/mpiton/zed-depsy/compare/v1.10.0...v2.0.0
 [1.10.0]: https://github.com/mpiton/zed-dependi/compare/v1.9.1...v1.10.0
 [1.9.1]: https://github.com/mpiton/zed-dependi/compare/v1.9.0...v1.9.1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 2.0.0
+**Version:** 2.0.1
 
 ![Demo](docs/demo.gif)
 

--- a/depsy-lsp/Cargo.lock
+++ b/depsy-lsp/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "depsy-lsp"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/depsy-lsp/Cargo.toml
+++ b/depsy-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "depsy-lsp"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/depsy-lsp/fuzz/Cargo.lock
+++ b/depsy-lsp/fuzz/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "depsy-lsp"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/depsy-zed/Cargo.lock
+++ b/depsy-zed/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "depsy-zed"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "sha2",
  "zed_extension_api",

--- a/depsy-zed/Cargo.toml
+++ b/depsy-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "depsy-zed"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"

--- a/depsy-zed/extension.toml
+++ b/depsy-zed/extension.toml
@@ -1,7 +1,7 @@
-id = "depsy"
+id = "depsy-lsp"
 name = "Depsy"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "2.0.0"
+version = "2.0.1"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-depsy"


### PR DESCRIPTION
## Summary

The Zed registry review for the `depsy` entry (zed-industries/extensions#7385) asks us to follow the new [publishing prerequisites](https://zed.dev/docs/extensions/publishing/prerequisites): an extension that only provides a language server needs an `-lsp` or `-language-server` suffix in its id. The registry uses `-lsp` far more often (33 vs 12 entries), and it matches the binary name, so the id becomes `depsy-lsp`.

Only the id changes. The extension name stays "Depsy", the settings key stays `lsp.depsy`, the cache dir and asset names are untouched. Version bumped to 2.0.1 so the registry entry points at a tagged release.

## Type of Change

- [x] Chore / release preparation

## Related Issue

#377, zed-industries/extensions#7385

## Changes Made

- `depsy-zed/extension.toml`: `id = "depsy-lsp"`, version 2.0.1
- Version 2.0.1 in `depsy-lsp/Cargo.toml`, `depsy-zed/Cargo.toml`, lockfiles (`cargo update -w`), README
- CHANGELOG: 2.0.1 entry and compare links

## Testing

- [x] `cargo build --release --target wasm32-wasip2 --locked` in `depsy-zed`
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` in `depsy-lsp`

## Checklist

- [x] CHANGELOG updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the Zed extension id from `depsy` to `depsy-lsp` so the registry entry meets Zed's publishing prerequisites for language-server-only extensions. Only the install id changes; the extension name stays "Depsy" and the settings key stays `lsp.depsy`. Version bumped to 2.0.1 with matching Cargo manifests, lockfiles, README, and changelog.

<sup>Written for commit f1fcfb6b5e6ef15b3c3cadde449ffd7fe08132e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/zed-depsy/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the extension and package version to 2.0.1.
  - Changed the extension ID from `depsy` to `depsy-lsp` while retaining the “Depsy” name and existing settings key.
  - Updated release notes, version documentation, and comparison links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->