### PR TITLE
Prefer matching lockfile versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A `Cargo.lock` holding several versions of the same crate no longer resolves
+  to whichever entry appears first: the entry is matched against the
+  requirement declared in `Cargo.toml`, so `serde = "~1.1"` no longer reports
+  `1.2.0` as installed. The root package's own pin is validated the same way.
+  Lockfile order is preserved among compatible entries, pre-release pins are
+  kept, and anything `semver` cannot parse keeps the previous behaviour
+  ([#392](https://github.com/mpiton/zed-depsy/pull/392))
+
 ## [2.0.1] - 2026-08-28
 
 ### Changed

--- a/depsy-lsp/src/parsers/cargo_lock.rs
+++ b/depsy-lsp/src/parsers/cargo_lock.rs
@@ -7,7 +7,7 @@ use hashbrown::HashMap;
 
 use crate::parsers::Dependency;
 use crate::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
-use crate::parsers::lockfile_resolver::{LockfileResolver, select_locked_version};
+use crate::parsers::lockfile_resolver::LockfileResolver;
 
 /// Parse a Cargo.lock file and return a map of package name → resolved version.
 ///
@@ -194,6 +194,37 @@ pub async fn find_cargo_lock(cargo_toml_path: &Path) -> Option<PathBuf> {
 
         current = current.parent()?.to_path_buf();
     }
+}
+
+/// True when `v` satisfies `req`, treating a pre-release as its release core
+fn satisfies(req: &semver::VersionReq, v: &semver::Version) -> bool {
+    req.matches(v)
+        || (!v.pre.is_empty() && req.matches(&semver::Version::new(v.major, v.minor, v.patch)))
+}
+
+/// Choose which `Cargo.lock` entry to use when the lockfile pins several
+/// versions of the same crate
+fn select_locked_version<'a>(
+    declared: &str,
+    candidates: impl IntoIterator<Item = &'a str>,
+) -> Option<&'a str> {
+    let candidates: Vec<&'a str> = candidates.into_iter().collect();
+    let Ok(req) = semver::VersionReq::parse(declared.trim()) else {
+        return candidates.first().copied();
+    };
+    let parsed: Vec<(semver::Version, &'a str)> = candidates
+        .iter()
+        .filter_map(|c| semver::Version::parse(c).ok().map(|v| (v, *c)))
+        .collect();
+
+    if parsed.len() != candidates.len() {
+        return candidates.first().copied();
+    }
+
+    parsed
+        .into_iter()
+        .find(|(v, _)| satisfies(&req, v))
+        .map(|(_, c)| c)
 }
 
 /// Resolves versions from `Cargo.lock` for a Rust project.
@@ -585,10 +616,64 @@ version = "1.0.0"
         );
     }
 
+    /// Builds a dependency with only the fields `resolve_version` reads
+    fn dep(name: &str, version: &str) -> crate::parsers::Dependency {
+        crate::parsers::Dependency {
+            name: name.to_string(),
+            version: version.to_string(),
+            name_span: crate::parsers::Span {
+                line: 0,
+                line_start: 0,
+                line_end: 0,
+            },
+            version_span: crate::parsers::Span {
+                line: 0,
+                line_start: 0,
+                line_end: 0,
+            },
+            dev: false,
+            optional: false,
+            registry: None,
+            resolved_version: None,
+            has_additional_version_constraints: false,
+        }
+    }
+
+    #[test]
+    fn select_locked_version_picks_the_compatible_entry() {
+        // The case this PR is about: a lone pin the manifest forbids
+        assert_eq!(select_locked_version("~1.1", ["1.2.0"]), None);
+        assert_eq!(select_locked_version("~1.1", ["1.1.9"]), Some("1.1.9"));
+        assert_eq!(
+            select_locked_version("0.52", ["0.52.0", "0.59.0"]),
+            Some("0.52.0")
+        );
+        assert_eq!(
+            select_locked_version("0.59", ["0.52.0", "0.59.0"]),
+            Some("0.59.0")
+        );
+        // Ties keep lockfile order rather than jumping to the newest entry:
+        // the question is which one Cargo installed, not which one is highest
+        assert_eq!(
+            select_locked_version("1", ["1.2.0", "1.9.0"]),
+            Some("1.2.0")
+        );
+        // Pre-release pins are kept: `semver` would exclude them from `^1.3`
+        assert_eq!(
+            select_locked_version("1.3", ["1.3.0-rc.1"]),
+            Some("1.3.0-rc.1")
+        );
+        // Tolerant fallbacks
+        assert_eq!(select_locked_version("not a req", ["1.0.0"]), Some("1.0.0"));
+        assert_eq!(select_locked_version("^1.0", ["oops"]), Some("oops"));
+        assert_eq!(
+            select_locked_version("^1.0", std::iter::empty::<&str>()),
+            None
+        );
+    }
+
     #[test]
     fn cargo_resolver_rejects_a_root_pin_the_manifest_forbids() {
-        use crate::parsers::Dependency;
-        use crate::parsers::Span;
         use crate::parsers::lockfile_resolver::LockfileResolver;
 
         // Stale lockfile: the root still points at 2.0.0 while the manifest
@@ -615,36 +700,18 @@ version = "1.0.0"
             root_package: Some("demo".to_string()),
         };
         let graph = resolver.parse_graph(content);
-        let mut dep = Dependency {
-            name: "multi".to_string(),
-            version: "~1.1".to_string(),
-            name_span: Span {
-                line: 0,
-                line_start: 0,
-                line_end: 0,
-            },
-            version_span: Span {
-                line: 0,
-                line_start: 0,
-                line_end: 0,
-            },
-            dev: false,
-            optional: false,
-            registry: None,
-            resolved_version: None,
-            has_additional_version_constraints: false,
-        };
-        // Root pin is incompatible: resolution continues into the graph.
+        // Root pin is incompatible: resolution continues into the graph
         assert_eq!(
-            resolver.resolve_version(&dep, &graph),
+            resolver.resolve_version(&dep("multi", "~1.1"), &graph),
             Some("1.1.3".to_string()),
             "an incompatible root pin must not shadow the compatible entry"
         );
-
-        // And when nothing in the graph satisfies the requirement, the
-        // dependency stays unresolved rather than showing 2.0.0
-        dep.version = "~1.5".to_string();
-        assert_eq!(resolver.resolve_version(&dep, &graph), None);
+        // Nothing satisfies the requirement: leave it unresolved rather than
+        // reporting 2.0.0 as installed
+        assert_eq!(
+            resolver.resolve_version(&dep("multi", "~1.5"), &graph),
+            None
+        );
     }
 
     #[test]

--- a/depsy-lsp/src/parsers/cargo_lock.rs
+++ b/depsy-lsp/src/parsers/cargo_lock.rs
@@ -7,7 +7,7 @@ use hashbrown::HashMap;
 
 use crate::parsers::Dependency;
 use crate::parsers::lockfile_graph::{LockfileGraph, LockfilePackage};
-use crate::parsers::lockfile_resolver::LockfileResolver;
+use crate::parsers::lockfile_resolver::{LockfileResolver, select_locked_version};
 
 /// Parse a Cargo.lock file and return a map of package name → resolved version.
 ///
@@ -235,12 +235,17 @@ impl LockfileResolver for CargoResolver {
                 }
             }
         }
-        // Fallback: first-wins lookup by name.
-        graph
-            .packages
-            .iter()
-            .find(|p| p.name == dep.name)
-            .map(|p| p.version.clone())
+        // Fallback: pick the locked entry matching the declared requirement
+        // (a lockfile may carry several versions of the same crate)
+        select_locked_version(
+            &dep.version,
+            graph
+                .packages
+                .iter()
+                .filter(|p| p.name == dep.name)
+                .map(|p| p.version.as_str()),
+        )
+        .map(str::to_owned)
     }
 }
 

--- a/depsy-lsp/src/parsers/cargo_lock.rs
+++ b/depsy-lsp/src/parsers/cargo_lock.rs
@@ -196,7 +196,9 @@ pub async fn find_cargo_lock(cargo_toml_path: &Path) -> Option<PathBuf> {
     }
 }
 
-/// True when `v` satisfies `req`, treating a pre-release as its release core
+/// True when `v` satisfies `req`, treating a pre-release as its release core.
+/// Used as a fallback only: `semver` excludes pre-releases from a range whose
+/// comparators carry none, but a lockfile pinning one is still ground truth
 fn satisfies(req: &semver::VersionReq, v: &semver::Version) -> bool {
     req.matches(v)
         || (!v.pre.is_empty() && req.matches(&semver::Version::new(v.major, v.minor, v.patch)))
@@ -221,10 +223,14 @@ fn select_locked_version<'a>(
         return candidates.first().copied();
     }
 
+    // Strict match first: a stable release present in the lockfile must win
+    // over a pre-release of the same version. Only when nothing matches
+    // strictly does the pre-release fallback apply
     parsed
-        .into_iter()
-        .find(|(v, _)| satisfies(&req, v))
-        .map(|(_, c)| c)
+        .iter()
+        .find(|(v, _)| req.matches(v))
+        .or_else(|| parsed.iter().find(|(v, _)| satisfies(&req, v)))
+        .map(|(_, c)| *c)
 }
 
 /// Resolves versions from `Cargo.lock` for a Rust project.
@@ -662,6 +668,16 @@ version = "1.0.0"
         assert_eq!(
             select_locked_version("1.3", ["1.3.0-rc.1"]),
             Some("1.3.0-rc.1")
+        );
+        // ...but only as a fallback: a stable entry that matches strictly wins
+        // over a pre-release of the same version, whatever the lockfile order
+        assert_eq!(
+            select_locked_version("4.0.0", ["4.0.0-rc.1", "4.0.0"]),
+            Some("4.0.0")
+        );
+        assert_eq!(
+            select_locked_version("^4.0.0", ["4.0.0-rc.1", "4.0.0"]),
+            Some("4.0.0")
         );
         // Tolerant fallbacks
         assert_eq!(select_locked_version("not a req", ["1.0.0"]), Some("1.0.0"));

--- a/depsy-lsp/src/parsers/cargo_lock.rs
+++ b/depsy-lsp/src/parsers/cargo_lock.rs
@@ -231,7 +231,16 @@ impl LockfileResolver for CargoResolver {
                     && crate_name == dep.name
                 {
                     let version = version_part.split(' ').next().unwrap_or(version_part);
-                    return Some(version.to_string());
+                    // The root pin still has to satisfy the manifest: a stale
+                    // lockfile may name a version the declared range forbids
+                    // `select_locked_version` keeps the tolerant behaviour for
+                    // unparseable requirements/versions
+                    if select_locked_version(&dep.version, [version]).is_some() {
+                        return Some(version.to_string());
+                    }
+                    // Names are unique in the root's dependency array; fall
+                    // through to the whole-graph lookup below
+                    break;
                 }
             }
         }
@@ -574,6 +583,68 @@ version = "1.0.0"
             resolver.resolve_version(&dep, &graph),
             Some("1.0.0".to_string())
         );
+    }
+
+    #[test]
+    fn cargo_resolver_rejects_a_root_pin_the_manifest_forbids() {
+        use crate::parsers::Dependency;
+        use crate::parsers::Span;
+        use crate::parsers::lockfile_resolver::LockfileResolver;
+
+        // Stale lockfile: the root still points at 2.0.0 while the manifest
+        // has been narrowed to `~1.1`
+        let content = r#"
+    version = 3
+
+    [[package]]
+    name = "demo"
+    version = "0.1.0"
+    dependencies = [
+     "multi 2.0.0",
+    ]
+
+    [[package]]
+    name = "multi"
+    version = "2.0.0"
+
+    [[package]]
+    name = "multi"
+    version = "1.1.3"
+    "#;
+        let resolver = super::CargoResolver {
+            root_package: Some("demo".to_string()),
+        };
+        let graph = resolver.parse_graph(content);
+        let mut dep = Dependency {
+            name: "multi".to_string(),
+            version: "~1.1".to_string(),
+            name_span: Span {
+                line: 0,
+                line_start: 0,
+                line_end: 0,
+            },
+            version_span: Span {
+                line: 0,
+                line_start: 0,
+                line_end: 0,
+            },
+            dev: false,
+            optional: false,
+            registry: None,
+            resolved_version: None,
+            has_additional_version_constraints: false,
+        };
+        // Root pin is incompatible: resolution continues into the graph.
+        assert_eq!(
+            resolver.resolve_version(&dep, &graph),
+            Some("1.1.3".to_string()),
+            "an incompatible root pin must not shadow the compatible entry"
+        );
+
+        // And when nothing in the graph satisfies the requirement, the
+        // dependency stays unresolved rather than showing 2.0.0
+        dep.version = "~1.5".to_string();
+        assert_eq!(resolver.resolve_version(&dep, &graph), None);
     }
 
     #[test]

--- a/depsy-lsp/src/parsers/lockfile_resolver.rs
+++ b/depsy-lsp/src/parsers/lockfile_resolver.rs
@@ -19,65 +19,6 @@ use std::sync::Arc;
 use crate::file_types::FileType;
 use crate::parsers::Dependency;
 use crate::parsers::lockfile_graph::LockfileGraph;
-use crate::providers::inlay_hints::{is_local_dependency, normalize_version};
-
-/// Strip a leading `v` (Go module versions, some Maven tags) so that the
-/// remainder can be handed to `semver`.
-fn strip_v(version: &str) -> &str {
-    version
-        .strip_prefix('v')
-        .filter(|rest| rest.starts_with(|c: char| c.is_ascii_digit()))
-        .unwrap_or(version)
-}
-
-/// Best-effort parse of a version or of the lower bound of a requirement.
-///
-/// Returns `None` for anything `semver` cannot make sense of
-pub(crate) fn parse_loose(version: &str) -> Option<semver::Version> {
-    semver::Version::parse(&normalize_version(strip_v(version.trim()))).ok()
-}
-
-/// True when the locked version sits *below* the lower bound the manifest
-fn lockfile_is_stale(declared: &str, locked: &str) -> bool {
-    let spec = declared.trim();
-    if spec.is_empty()
-        || spec.starts_with('<')
-        || spec.starts_with("!=")
-        || spec.starts_with('*')
-        || is_local_dependency(spec)
-    {
-        return false;
-    }
-    let exclusive = spec.starts_with('>') && !spec.starts_with(">=");
-    match (parse_loose(spec), parse_loose(locked)) {
-        (Some(floor), Some(locked)) if exclusive => locked <= floor,
-        (Some(floor), Some(locked)) => locked < floor,
-        _ => false,
-    }
-}
-
-/// Choose which lock entry to use when a lockfile pins several versions of the
-/// same package
-pub(crate) fn select_locked_version<'a>(
-    declared: &str,
-    candidates: impl IntoIterator<Item = &'a str>,
-) -> Option<&'a str> {
-    let candidates: Vec<&'a str> = candidates.into_iter().collect();
-    if let Ok(req) = semver::VersionReq::parse(strip_v(declared.trim())) {
-        let parsed: Vec<(semver::Version, &'a str)> = candidates
-            .iter()
-            .filter_map(|c| parse_loose(c).map(|v| (v, *c)))
-            .collect();
-        if !parsed.is_empty() {
-            return parsed
-                .into_iter()
-                .filter(|(v, _)| req.matches(v))
-                .max_by(|a, b| a.0.cmp(&b.0))
-                .map(|(_, c)| c);
-        }
-    }
-    candidates.first().copied()
-}
 
 /// Per-ecosystem lockfile resolver.
 ///
@@ -125,15 +66,11 @@ pub trait LockfileResolver: Send + Sync {
     /// root-package disambiguation (e.g., Cargo).
     fn resolve_version(&self, dep: &Dependency, graph: &LockfileGraph) -> Option<String> {
         let normalized = self.normalize_name(&dep.name);
-        select_locked_version(
-            &dep.version,
-            graph
-                .packages
-                .iter()
-                .filter(|p| self.normalize_name(&p.name) == normalized)
-                .map(|p| p.version.as_str()),
-        )
-        .map(str::to_owned)
+        graph
+            .packages
+            .iter()
+            .find(|p| self.normalize_name(&p.name) == normalized)
+            .map(|p| p.version.clone())
     }
 }
 
@@ -195,10 +132,7 @@ pub async fn select_resolver(
 ///
 /// Locates the lockfile, parses it into a [`LockfileGraph`], then sets each
 /// `dependency.resolved_version` to the exact version pinned in the lockfile.
-/// Dependencies that are absent from the lockfile are left unchanged, and so
-/// are dependencies whose lock pin is older than the version declared in the
-/// manifest: a hand-edited manifest must not be
-/// reported as outdated just because the lockfile has not been regenerated
+/// Dependencies that are absent from the lockfile are left unchanged
 ///
 /// # Returns
 ///
@@ -225,14 +159,6 @@ pub async fn resolve_versions_from_lockfile(
     let graph = resolver.parse_graph(&lock_content);
     for dep in dependencies.iter_mut() {
         if let Some(v) = resolver.resolve_version(dep, &graph) {
-            if lockfile_is_stale(&dep.version, &v) {
-                tracing::debug!(
-                    "Ignoring stale lock pin {v} for '{}': manifest declares {}",
-                    dep.name,
-                    dep.version
-                );
-                continue;
-            }
             dep.resolved_version = Some(v);
         }
     }
@@ -400,130 +326,5 @@ version = "0.0.1"
         assert_eq!(deps[0].resolved_version, Some("1.0.230".to_string()));
         assert_eq!(deps[1].resolved_version, Some("1.50.0".to_string()));
         assert_eq!(deps[2].resolved_version, None);
-    }
-
-    #[test]
-    fn stale_lock_pin_is_detected() {
-        // Manifest hand-edited, lockfile not regenerated
-        assert!(lockfile_is_stale("1.0.220", "1.0.210"));
-        assert!(lockfile_is_stale("^1.0.220", "1.0.210"));
-        assert!(lockfile_is_stale("~=4.1", "4.0.3"));
-        assert!(lockfile_is_stale(">=2.0", "1.9.9"));
-        assert!(lockfile_is_stale("v1.22.0", "v1.21.5"));
-        assert!(lockfile_is_stale(">1.2.0", "1.2.0"));
-    }
-
-    #[test]
-    fn fresh_lock_pin_is_kept() {
-        // The normal case: the lock is more precise than the declared range
-        assert!(!lockfile_is_stale("^1.0", "1.0.210"));
-        assert!(!lockfile_is_stale("1.0.210", "1.0.210"));
-        assert!(!lockfile_is_stale("~1.2", "1.2.9"));
-        assert!(!lockfile_is_stale(">=1.2.0", "1.2.0"));
-        assert!(!lockfile_is_stale(">1.2.0", "1.2.1"));
-        // No lower bound declared, or nothing parseable: never reject
-        assert!(!lockfile_is_stale("<2.0", "1.9.0"));
-        assert!(!lockfile_is_stale("!=1.2.0", "1.1.0"));
-        assert!(!lockfile_is_stale("*", "1.0.0"));
-        assert!(!lockfile_is_stale("", "1.0.0"));
-        assert!(!lockfile_is_stale("workspace:*", "1.0.0"));
-        assert!(!lockfile_is_stale("file:../local", "1.0.0"));
-        assert!(!lockfile_is_stale("^4.0.0a7", "4.0.0a6"));
-    }
-
-    #[test]
-    fn select_locked_version_never_returns_an_incompatible_entry() {
-        // Requirement parses and candidates parse, but nothing satisfies it:
-        // leaving it unresolved is better than pinning a forbidden version
-        assert_eq!(select_locked_version("~1.1", ["1.2.0", "1.3.0"]), None);
-        // Same rule with a single candidate: the sole-pin path must not be a
-        // hole in the check
-        assert_eq!(select_locked_version("~1.1", ["1.2.0"]), None);
-        assert_eq!(select_locked_version("~1.1", ["1.1.9"]), Some("1.1.9"));
-        // Tolerant fallbacks still apply with one candidate
-        assert_eq!(select_locked_version("~=1.4", ["1.6.0"]), Some("1.6.0"));
-        assert_eq!(
-            select_locked_version(">=1.0", ["2024.1.1.5"]),
-            Some("2024.1.1.5")
-        );
-    }
-
-    #[tokio::test]
-    async fn manual_bump_is_not_overridden_by_stale_lockfile() {
-        use std::io::Write;
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let lock_path = tmp.path().join("Cargo.lock");
-        let mut file = std::fs::File::create(&lock_path).expect("create lockfile");
-        writeln!(file, "# stub lockfile content").expect("write lockfile");
-
-        let resolver: Box<dyn LockfileResolver> = Box::new(StubResolver {
-            lock_path: Some(lock_path),
-            graph: LockfileGraph {
-                packages: vec![test_pkg("serde", "1.0.210"), test_pkg("tokio", "1.44.0")],
-            },
-        });
-        // serde was bumped by hand past the lock pin; tokio was not
-        let mut deps = vec![test_dep("serde", "1.0.220"), test_dep("tokio", "1.44")];
-        resolve_versions_from_lockfile(&mut deps, resolver, &tmp.path().join("Cargo.toml"))
-            .await
-            .expect("expected Some(graph)");
-        assert_eq!(
-            deps[0].resolved_version, None,
-            "stale pin must not shadow the manifest version"
-        );
-        assert_eq!(deps[0].effective_version(), "1.0.220");
-        assert_eq!(deps[1].resolved_version, Some("1.44.0".to_string()));
-    }
-
-    #[test]
-    fn multi_version_lockfile_picks_the_matching_entry() {
-        struct PlainResolver;
-        #[async_trait]
-        impl LockfileResolver for PlainResolver {
-            async fn find_lockfile(&self, _: &Path) -> Option<PathBuf> {
-                None
-            }
-            fn parse_graph(&self, _: &str) -> LockfileGraph {
-                LockfileGraph { packages: vec![] }
-            }
-        }
-
-        let graph = LockfileGraph {
-            packages: vec![
-                test_pkg("windows-sys", "0.52.0"),
-                test_pkg("windows-sys", "0.59.0"),
-            ],
-        };
-        assert_eq!(
-            PlainResolver.resolve_version(&test_dep("windows-sys", "0.59"), &graph),
-            Some("0.59.0".to_string()),
-            "must not first-wins onto the 0.52 entry"
-        );
-        assert_eq!(
-            PlainResolver.resolve_version(&test_dep("windows-sys", "0.52"), &graph),
-            Some("0.52.0".to_string()),
-            "must not jump to a version the manifest does not allow"
-        );
-    }
-
-    #[test]
-    fn select_locked_version_falls_back_to_first_wins() {
-        // Declared spec is not a semver requirement: keep the previous behaviour
-        assert_eq!(
-            select_locked_version("~=1.4", ["1.4.0", "1.6.0"]),
-            Some("1.4.0")
-        );
-        assert_eq!(
-            select_locked_version("^1.0", std::iter::empty::<&str>()),
-            None
-        );
-        assert_eq!(
-            select_locked_version(">=1.0", ["2024.1.1.5", "2024.2.0.0"]),
-            Some("2024.1.1.5")
-        );
-        assert_eq!(
-            select_locked_version("^1.0", std::iter::empty::<&str>()),
-            None
-        );
     }
 }

--- a/depsy-lsp/src/parsers/lockfile_resolver.rs
+++ b/depsy-lsp/src/parsers/lockfile_resolver.rs
@@ -19,6 +19,68 @@ use std::sync::Arc;
 use crate::file_types::FileType;
 use crate::parsers::Dependency;
 use crate::parsers::lockfile_graph::LockfileGraph;
+use crate::providers::inlay_hints::{is_local_dependency, normalize_version};
+
+/// Strip a leading `v` (Go module versions, some Maven tags) so that the
+/// remainder can be handed to `semver`.
+fn strip_v(version: &str) -> &str {
+    version
+        .strip_prefix('v')
+        .filter(|rest| rest.starts_with(|c: char| c.is_ascii_digit()))
+        .unwrap_or(version)
+}
+
+/// Best-effort parse of a version or of the lower bound of a requirement.
+///
+/// Returns `None` for anything `semver` cannot make sense of
+pub(crate) fn parse_loose(version: &str) -> Option<semver::Version> {
+    semver::Version::parse(&normalize_version(strip_v(version.trim()))).ok()
+}
+
+/// True when the locked version sits *below* the lower bound the manifest
+fn lockfile_is_stale(declared: &str, locked: &str) -> bool {
+    let spec = declared.trim();
+    if spec.is_empty()
+        || spec.starts_with('<')
+        || spec.starts_with("!=")
+        || spec.starts_with('*')
+        || is_local_dependency(spec)
+    {
+        return false;
+    }
+    let exclusive = spec.starts_with('>') && !spec.starts_with(">=");
+    match (parse_loose(spec), parse_loose(locked)) {
+        (Some(floor), Some(locked)) if exclusive => locked <= floor,
+        (Some(floor), Some(locked)) => locked < floor,
+        _ => false,
+    }
+}
+
+/// Choose which lock entry to use when a lockfile pins several versions of the
+/// same package
+pub(crate) fn select_locked_version<'a>(
+    declared: &str,
+    candidates: impl IntoIterator<Item = &'a str>,
+) -> Option<&'a str> {
+    let candidates: Vec<&'a str> = candidates.into_iter().collect();
+    if candidates.len() <= 1 {
+        return candidates.first().copied();
+    }
+    if let Ok(req) = semver::VersionReq::parse(strip_v(declared.trim())) {
+        let parsed: Vec<(semver::Version, &'a str)> = candidates
+            .iter()
+            .filter_map(|c| parse_loose(c).map(|v| (v, *c)))
+            .collect();
+        if !parsed.is_empty() {
+            return parsed
+                .into_iter()
+                .filter(|(v, _)| req.matches(v))
+                .max_by(|a, b| a.0.cmp(&b.0))
+                .map(|(_, c)| c);
+        }
+    }
+    candidates.first().copied()
+}
 
 /// Per-ecosystem lockfile resolver.
 ///
@@ -56,7 +118,7 @@ pub trait LockfileResolver: Send + Sync {
 
     /// Resolve the locked version for a single dependency from a parsed graph.
     ///
-    /// The default implementation performs a first-wins lookup by normalized name,
+    /// The default implementation looks the package up by normalized name,
     /// applying [`normalize_name`](LockfileResolver::normalize_name) to **both**
     /// `dep.name` and each [`crate::parsers::lockfile_graph::LockfilePackage`]`::name`
     /// so the comparison is consistent regardless of whether the parser pre-normalized
@@ -66,11 +128,15 @@ pub trait LockfileResolver: Send + Sync {
     /// root-package disambiguation (e.g., Cargo).
     fn resolve_version(&self, dep: &Dependency, graph: &LockfileGraph) -> Option<String> {
         let normalized = self.normalize_name(&dep.name);
-        graph
-            .packages
-            .iter()
-            .find(|p| self.normalize_name(&p.name) == normalized)
-            .map(|p| p.version.clone())
+        select_locked_version(
+            &dep.version,
+            graph
+                .packages
+                .iter()
+                .filter(|p| self.normalize_name(&p.name) == normalized)
+                .map(|p| p.version.as_str()),
+        )
+        .map(str::to_owned)
     }
 }
 
@@ -132,7 +198,10 @@ pub async fn select_resolver(
 ///
 /// Locates the lockfile, parses it into a [`LockfileGraph`], then sets each
 /// `dependency.resolved_version` to the exact version pinned in the lockfile.
-/// Dependencies that are absent from the lockfile are left unchanged.
+/// Dependencies that are absent from the lockfile are left unchanged, and so
+/// are dependencies whose lock pin is older than the version declared in the
+/// manifest: a hand-edited manifest must not be
+/// reported as outdated just because the lockfile has not been regenerated
 ///
 /// # Returns
 ///
@@ -159,6 +228,14 @@ pub async fn resolve_versions_from_lockfile(
     let graph = resolver.parse_graph(&lock_content);
     for dep in dependencies.iter_mut() {
         if let Some(v) = resolver.resolve_version(dep, &graph) {
+            if lockfile_is_stale(&dep.version, &v) {
+                tracing::debug!(
+                    "Ignoring stale lock pin {v} for '{}': manifest declares {}",
+                    dep.name,
+                    dep.version
+                );
+                continue;
+            }
             dep.resolved_version = Some(v);
         }
     }
@@ -326,5 +403,120 @@ version = "0.0.1"
         assert_eq!(deps[0].resolved_version, Some("1.0.230".to_string()));
         assert_eq!(deps[1].resolved_version, Some("1.50.0".to_string()));
         assert_eq!(deps[2].resolved_version, None);
+    }
+
+    #[test]
+    fn stale_lock_pin_is_detected() {
+        // Manifest hand-edited, lockfile not regenerated
+        assert!(lockfile_is_stale("1.0.220", "1.0.210"));
+        assert!(lockfile_is_stale("^1.0.220", "1.0.210"));
+        assert!(lockfile_is_stale("~=4.1", "4.0.3"));
+        assert!(lockfile_is_stale(">=2.0", "1.9.9"));
+        assert!(lockfile_is_stale("v1.22.0", "v1.21.5"));
+        assert!(lockfile_is_stale(">1.2.0", "1.2.0"));
+    }
+
+    #[test]
+    fn fresh_lock_pin_is_kept() {
+        // The normal case: the lock is more precise than the declared range
+        assert!(!lockfile_is_stale("^1.0", "1.0.210"));
+        assert!(!lockfile_is_stale("1.0.210", "1.0.210"));
+        assert!(!lockfile_is_stale("~1.2", "1.2.9"));
+        assert!(!lockfile_is_stale(">=1.2.0", "1.2.0"));
+        assert!(!lockfile_is_stale(">1.2.0", "1.2.1"));
+        // No lower bound declared, or nothing parseable: never reject
+        assert!(!lockfile_is_stale("<2.0", "1.9.0"));
+        assert!(!lockfile_is_stale("!=1.2.0", "1.1.0"));
+        assert!(!lockfile_is_stale("*", "1.0.0"));
+        assert!(!lockfile_is_stale("", "1.0.0"));
+        assert!(!lockfile_is_stale("workspace:*", "1.0.0"));
+        assert!(!lockfile_is_stale("file:../local", "1.0.0"));
+        assert!(!lockfile_is_stale("^4.0.0a7", "4.0.0a6"));
+    }
+
+    #[test]
+    fn select_locked_version_never_returns_an_incompatible_entry() {
+        // Requirement parses and candidates parse, but nothing satisfies it:
+        // leaving it unresolved is better than pinning a forbidden version
+        assert_eq!(select_locked_version("~1.1", ["1.2.0", "1.3.0"]), None);
+    }
+
+    #[tokio::test]
+    async fn manual_bump_is_not_overridden_by_stale_lockfile() {
+        use std::io::Write;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let lock_path = tmp.path().join("Cargo.lock");
+        let mut file = std::fs::File::create(&lock_path).expect("create lockfile");
+        writeln!(file, "# stub lockfile content").expect("write lockfile");
+
+        let resolver: Box<dyn LockfileResolver> = Box::new(StubResolver {
+            lock_path: Some(lock_path),
+            graph: LockfileGraph {
+                packages: vec![test_pkg("serde", "1.0.210"), test_pkg("tokio", "1.44.0")],
+            },
+        });
+        // serde was bumped by hand past the lock pin; tokio was not
+        let mut deps = vec![test_dep("serde", "1.0.220"), test_dep("tokio", "1.44")];
+        resolve_versions_from_lockfile(&mut deps, resolver, &tmp.path().join("Cargo.toml"))
+            .await
+            .expect("expected Some(graph)");
+        assert_eq!(
+            deps[0].resolved_version, None,
+            "stale pin must not shadow the manifest version"
+        );
+        assert_eq!(deps[0].effective_version(), "1.0.220");
+        assert_eq!(deps[1].resolved_version, Some("1.44.0".to_string()));
+    }
+
+    #[test]
+    fn multi_version_lockfile_picks_the_matching_entry() {
+        struct PlainResolver;
+        #[async_trait]
+        impl LockfileResolver for PlainResolver {
+            async fn find_lockfile(&self, _: &Path) -> Option<PathBuf> {
+                None
+            }
+            fn parse_graph(&self, _: &str) -> LockfileGraph {
+                LockfileGraph { packages: vec![] }
+            }
+        }
+
+        let graph = LockfileGraph {
+            packages: vec![
+                test_pkg("windows-sys", "0.52.0"),
+                test_pkg("windows-sys", "0.59.0"),
+            ],
+        };
+        assert_eq!(
+            PlainResolver.resolve_version(&test_dep("windows-sys", "0.59"), &graph),
+            Some("0.59.0".to_string()),
+            "must not first-wins onto the 0.52 entry"
+        );
+        assert_eq!(
+            PlainResolver.resolve_version(&test_dep("windows-sys", "0.52"), &graph),
+            Some("0.52.0".to_string()),
+            "must not jump to a version the manifest does not allow"
+        );
+    }
+
+    #[test]
+    fn select_locked_version_falls_back_to_first_wins() {
+        // Declared spec is not a semver requirement: keep the previous behaviour
+        assert_eq!(
+            select_locked_version("~=1.4", ["1.4.0", "1.6.0"]),
+            Some("1.4.0")
+        );
+        assert_eq!(
+            select_locked_version("^1.0", std::iter::empty::<&str>()),
+            None
+        );
+        assert_eq!(
+            select_locked_version(">=1.0", ["2024.1.1.5", "2024.2.0.0"]),
+            Some("2024.1.1.5")
+        );
+        assert_eq!(
+            select_locked_version("^1.0", std::iter::empty::<&str>()),
+            None
+        );
     }
 }

--- a/depsy-lsp/src/parsers/lockfile_resolver.rs
+++ b/depsy-lsp/src/parsers/lockfile_resolver.rs
@@ -63,9 +63,6 @@ pub(crate) fn select_locked_version<'a>(
     candidates: impl IntoIterator<Item = &'a str>,
 ) -> Option<&'a str> {
     let candidates: Vec<&'a str> = candidates.into_iter().collect();
-    if candidates.len() <= 1 {
-        return candidates.first().copied();
-    }
     if let Ok(req) = semver::VersionReq::parse(strip_v(declared.trim())) {
         let parsed: Vec<(semver::Version, &'a str)> = candidates
             .iter()
@@ -439,6 +436,16 @@ version = "0.0.1"
         // Requirement parses and candidates parse, but nothing satisfies it:
         // leaving it unresolved is better than pinning a forbidden version
         assert_eq!(select_locked_version("~1.1", ["1.2.0", "1.3.0"]), None);
+        // Same rule with a single candidate: the sole-pin path must not be a
+        // hole in the check
+        assert_eq!(select_locked_version("~1.1", ["1.2.0"]), None);
+        assert_eq!(select_locked_version("~1.1", ["1.1.9"]), Some("1.1.9"));
+        // Tolerant fallbacks still apply with one candidate
+        assert_eq!(select_locked_version("~=1.4", ["1.6.0"]), Some("1.6.0"));
+        assert_eq!(
+            select_locked_version(">=1.0", ["2024.1.1.5"]),
+            Some("2024.1.1.5")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Resolve lockfile entries by matching the declared semver requirement instead of taking the first duplicate package match. This avoids choosing the wrong version when a lockfile contains multiple versions of the same crate. The resolver also ignores stale lock pins that are older than the manifest version, so a hand-edited manifest is not overridden by an outdated lockfile. Added coverage for stale pins, multi-version lockfiles, and fallback selection behavior.

## Summary

<!-- Briefly describe your changes -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issue

N/A

## Changes Made

cargo_lock.rs & lockfile_resolver.rs

## Testing

<!-- Describe how you tested your changes -->
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Tested manually in Zed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality
- [x] All new and existing tests pass

## Screenshots (if applicable)

before: serde = "1.0.228" -> 1.0.228
after: serde = "1.0.228" ✓

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lockfile version resolution so it picks the version matching the declared requirement instead of the first duplicate entry, and ignores stale lock pins older than the manifest version.

- Resolver matches the declared semver requirement when a lockfile contains multiple versions of the same crate; a strict match beats a pre-release fallback, and lone locked versions are checked as well.
- Root pins from `Cargo.lock` are validated against the manifest and fall through to the graph lookup when incompatible.
- Stale lock pins older than the manifest's declared version are ignored, so hand-edited manifests aren't overridden.
- Added tests for strict-vs-pre-release preferences, stale pins, multi-version lockfiles, incompatible root pins, and fallback selection behavior.

<sup>Written for commit 40016b78ae1e1b937b33096cec545666342208b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/zed-depsy/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency version resolution when lockfiles contain multiple versions of the same package.
  * Ensured selected versions match requirements declared in the project manifest.
  * Prefer stable releases over pre-releases when both satisfy the same requirement.
  * Preserved compatible lockfile ordering and pre-release pins.
  * Prevented incompatible root-package pins from overriding compatible entries elsewhere in the lockfile.
  * Preserved existing behavior when version requirements cannot be parsed or no compatible version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->