### PR TITLE
chore(deps): consolidate dependabot updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -38,7 +38,7 @@ jobs:
           cargo codspeed build --bench benchmarks
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         with:
           mode: simulation
           run: cd depsy-lsp && cargo codspeed run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rust dependencies refreshed: `tokio` 1.53.1, `clap` 4.6.6, `serde` 1.0.229,
+  `serde_json` 1.0.151, `anyhow` 1.0.104, `futures` 0.3.34, `quick-xml` 0.42,
+  `serial_test` 4, plus lockfile bumps for `toml`, `rusqlite` and `async-trait`.
+  `quick-xml` 0.42 decodes at the reader level, so the Maven, Maven Central and
+  NuGet XML parsers now work on `&str` instead of `&[u8]`; parsing behaviour and
+  reported spans are unchanged.
+- CI: `actions/setup-node` v7 and `CodSpeedHQ/action` v5.
+
 ## [2.0.1] - 2026-08-28
 
 ### Changed

--- a/depsy-lsp/Cargo.lock
+++ b/depsy-lsp/Cargo.lock
@@ -81,7 +81,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -92,14 +92,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -131,13 +131,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -326,14 +326,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -603,7 +603,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -642,7 +642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -704,9 +704,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -729,15 +729,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -746,38 +746,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1201,7 +1201,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1335,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1466,7 +1466,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1933,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",
@@ -1977,7 +1977,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2034,7 +2034,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2125,9 +2125,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2135,29 +2135,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2261,7 +2261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2327,6 +2327,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,7 +2388,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2503,9 +2514,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2552,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2576,18 +2587,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -2977,7 +2988,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/depsy-lsp/Cargo.lock
+++ b/depsy-lsp/Cargo.lock
@@ -1658,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -2188,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -2202,13 +2202,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/depsy-lsp/Cargo.toml
+++ b/depsy-lsp/Cargo.toml
@@ -35,13 +35,13 @@ clap = { version = "4.6.6", features = ["derive"] }
 futures = "0.3.34"
 taplo = "0.14"
 hashbrown = { version = "0.17.1", features = ["serde"] }
-quick-xml = "0.41.0"
+quick-xml = "0.42.0"
 url = "2.5"
 async-trait = "0.1"
 json-spanned-value = "0.2.2"
 
 [dev-dependencies]
-serial_test = "3"
+serial_test = "4"
 wiremock = "0.6"
 tempfile = "3"
 criterion = { version = "4.6.0", package = "codspeed-criterion-compat", features = ["html_reports"] }

--- a/depsy-lsp/Cargo.toml
+++ b/depsy-lsp/Cargo.toml
@@ -17,22 +17,22 @@ path = "src/main.rs"
 
 [dependencies]
 tower-lsp = "0.20"
-tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync", "time"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
+tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros", "io-util", "io-std", "fs", "sync", "time"] }
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
 reqwest = { version = "0.13.4", features = ["json", "rustls"], default-features = false }
 dashmap = "6.2.1"
 toml = "1.0.7"
 semver = "1.0.27"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-anyhow = "1.0.103"
+anyhow = "1.0.104"
 rusqlite = { version = "0.40", features = ["bundled"] }
 r2d2 = "0.8"
 dirs = "6"
 chrono = { version = "0.4.45", features = ["serde"] }
-clap = { version = "4.5.60", features = ["derive"] }
-futures = "0.3.32"
+clap = { version = "4.6.6", features = ["derive"] }
+futures = "0.3.34"
 taplo = "0.14"
 hashbrown = { version = "0.17.1", features = ["serde"] }
 quick-xml = "0.41.0"
@@ -45,7 +45,7 @@ serial_test = "3"
 wiremock = "0.6"
 tempfile = "3"
 criterion = { version = "4.6.0", package = "codspeed-criterion-compat", features = ["html_reports"] }
-tokio = { version = "1.52.3", features = ["net"] }
+tokio = { version = "1.53.1", features = ["net"] }
 
 [[bench]]
 name = "benchmarks"

--- a/depsy-lsp/fuzz/Cargo.lock
+++ b/depsy-lsp/fuzz/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -237,6 +237,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -262,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -274,14 +285,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -336,6 +347,15 @@ name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -513,9 +533,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -528,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -538,15 +558,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -555,38 +575,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -619,10 +639,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "wasip2",
+ "r-efi 6.0.0",
+ "rand_core",
  "wasm-bindgen",
 ]
 
@@ -1289,15 +1321,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -1337,15 +1360,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
  "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -1387,6 +1411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "r2d2"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,31 +1429,28 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1724,9 +1751,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1734,29 +1761,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1884,6 +1911,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2044,9 +2082,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",

--- a/depsy-lsp/src/parsers/csharp.rs
+++ b/depsy-lsp/src/parsers/csharp.rs
@@ -22,11 +22,11 @@ enum NugetItemKind {
 }
 
 impl NugetItemKind {
-    fn from_local_name(name: &[u8]) -> Option<Self> {
+    fn from_local_name(name: &str) -> Option<Self> {
         match name {
-            b"PackageReference" => Some(Self::PackageReference),
-            b"PackageVersion" => Some(Self::PackageVersion),
-            b"GlobalPackageReference" => Some(Self::GlobalPackageReference),
+            "PackageReference" => Some(Self::PackageReference),
+            "PackageVersion" => Some(Self::PackageVersion),
+            "GlobalPackageReference" => Some(Self::GlobalPackageReference),
             _ => None,
         }
     }
@@ -63,7 +63,7 @@ impl PendingItem {
         for attribute in event.attributes() {
             let attribute = attribute.map_err(|_| ())?;
             let key = attribute.key.as_ref();
-            if !matches!(key, b"Include" | b"Update" | b"Version") {
+            if !matches!(key, "Include" | "Update" | "Version") {
                 continue;
             }
 
@@ -72,16 +72,16 @@ impl PendingItem {
                 attribute_value_range(event, raw_value).ok_or(())?;
             let value = LocatedValue {
                 value: attribute
-                    .decoded_and_normalized_value(XmlVersion::Implicit1_0, event.decoder())
+                    .normalized_value(XmlVersion::Implicit1_0)
                     .map_err(|_| ())?
                     .into_owned(),
                 absolute_start: event_start.checked_add(relative_start).ok_or(())?,
                 absolute_end: event_start.checked_add(relative_end).ok_or(())?,
             };
             match key {
-                b"Include" => include = Some(value),
-                b"Update" => update = Some(value),
-                b"Version" => version = Some(value),
+                "Include" => include = Some(value),
+                "Update" => update = Some(value),
+                "Version" => version = Some(value),
                 _ => {}
             }
         }
@@ -119,8 +119,8 @@ impl ActiveItem {
         }
     }
 
-    fn begin_child_version(&mut self, local_name: &[u8], event_depth: usize) {
-        if local_name == b"Version"
+    fn begin_child_version(&mut self, local_name: &str, event_depth: usize) {
+        if local_name == "Version"
             && self.item.version.is_none()
             && self.item_depth.checked_add(1) == Some(event_depth)
         {
@@ -285,12 +285,12 @@ impl<'a> ParseState<'a> {
         Ok(())
     }
 
-    fn handle_end(&mut self, local_name: &[u8]) -> Result<(), ()> {
+    fn handle_end(&mut self, local_name: &str) -> Result<(), ()> {
         let event_depth = self.depth.checked_sub(1).ok_or(())?;
         self.depth = event_depth;
 
         if self.active.as_ref().and_then(|active| active.version_depth) == Some(event_depth) {
-            if local_name != b"Version" {
+            if local_name != "Version" {
                 return Err(());
             }
             self.active.as_mut().ok_or(())?.version_depth = None;
@@ -380,12 +380,12 @@ fn parse_xml(content: &str) -> Result<Vec<Dependency>, ()> {
     }
 }
 
-fn is_xml_whitespace(value: &[u8]) -> bool {
-    value.iter().all(u8::is_ascii_whitespace)
+fn is_xml_whitespace(value: &str) -> bool {
+    value.bytes().all(|byte| byte.is_ascii_whitespace())
 }
 
 fn validate_xml_declaration(declaration: &BytesDecl<'_>) -> Result<(), ()> {
-    let raw = std::str::from_utf8(declaration.as_ref()).map_err(|_| ())?;
+    let raw: &str = declaration.as_ref();
     if !raw.as_bytes().get(3).is_some_and(u8::is_ascii_whitespace) {
         return Err(());
     }
@@ -397,9 +397,9 @@ fn validate_xml_declaration(declaration: &BytesDecl<'_>) -> Result<(), ()> {
         let key = attribute.key.as_ref();
         let value = attribute.value.as_ref();
         attribute_position = match (attribute_position, key) {
-            (0, b"version") if matches!(value, b"1.0" | b"1.1") => 1,
-            (1, b"encoding") if is_valid_xml_encoding(value) => 2,
-            (1 | 2, b"standalone") if matches!(value, b"yes" | b"no") => 3,
+            (0, "version") if matches!(value, "1.0" | "1.1") => 1,
+            (1, "encoding") if is_valid_xml_encoding(value) => 2,
+            (1 | 2, "standalone") if matches!(value, "yes" | "no") => 3,
             _ => return Err(()),
         };
     }
@@ -411,12 +411,10 @@ fn validate_xml_declaration(declaration: &BytesDecl<'_>) -> Result<(), ()> {
     }
 }
 
-fn is_valid_xml_encoding(value: &[u8]) -> bool {
-    value.first().is_some_and(u8::is_ascii_alphabetic)
-        && value
-            .iter()
-            .skip(1)
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+fn is_valid_xml_encoding(value: &str) -> bool {
+    let mut bytes = value.bytes();
+    bytes.next().is_some_and(|byte| byte.is_ascii_alphabetic())
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
 }
 
 fn is_supported_xml_reference(reference: &BytesRef<'_>) -> bool {
@@ -425,9 +423,7 @@ fn is_supported_xml_reference(reference: &BytesRef<'_>) -> bool {
             u32::from(character),
             0x9 | 0xA | 0xD | 0x20..=0xD7FF | 0xE000..=0xFFFD | 0x10000..=0x10FFFF
         ),
-        Ok(None) => reference
-            .decode()
-            .is_ok_and(|entity| resolve_xml_entity(&entity).is_some()),
+        Ok(None) => resolve_xml_entity(reference).is_some(),
         Err(_) => false,
     }
 }
@@ -513,7 +509,7 @@ fn span_from_absolute(
 
 fn event_content_start(event_end: u64, event: &BytesStart<'_>, is_empty: bool) -> Option<usize> {
     let event_end = usize::try_from(event_end).ok()?;
-    let event_raw: &[u8] = event.as_ref();
+    let event_raw: &str = event.as_ref();
     let closing_delimiter_len = if is_empty { 2 } else { 1 };
     event_end
         .checked_sub(event_raw.len())?
@@ -533,7 +529,7 @@ fn located_text(
     content: &str,
 ) -> Result<Option<LocatedValue>, ()> {
     let event_end = usize::try_from(event_end).map_err(|_| ())?;
-    let raw_text: &[u8] = text.as_ref();
+    let raw_text: &str = text.as_ref();
     let raw_start = event_end.checked_sub(raw_text.len()).ok_or(())?;
     let raw = content.get(raw_start..event_end).ok_or(())?;
     let raw_without_leading = raw.trim_start();
@@ -545,7 +541,7 @@ fn located_text(
 
     let absolute_start = raw_start.checked_add(leading_len).ok_or(())?;
     let absolute_end = absolute_start.checked_add(trimmed_raw.len()).ok_or(())?;
-    let value = text.decode().map_err(|_| ())?.trim().to_string();
+    let value = text.trim().to_string();
 
     Ok(Some(LocatedValue {
         value,
@@ -554,8 +550,8 @@ fn located_text(
     }))
 }
 
-fn attribute_value_range(event: &BytesStart<'_>, value: &[u8]) -> Option<(usize, usize)> {
-    let raw: &[u8] = event.as_ref();
+fn attribute_value_range(event: &BytesStart<'_>, value: &str) -> Option<(usize, usize)> {
+    let raw: &str = event.as_ref();
     let start = (value.as_ptr() as usize).checked_sub(raw.as_ptr() as usize)?;
     let end = start.checked_add(value.len())?;
     raw.get(start..end)?;

--- a/depsy-lsp/src/parsers/maven.rs
+++ b/depsy-lsp/src/parsers/maven.rs
@@ -110,7 +110,7 @@ fn extract_properties(content: &str) -> HashMap<String, String> {
     reader.config_mut().trim_text(true);
 
     let mut out = HashMap::new();
-    let mut depth_stack: Vec<Vec<u8>> = Vec::new();
+    let mut depth_stack: Vec<String> = Vec::new();
     let mut current_key: Option<String> = None;
 
     loop {
@@ -118,33 +118,30 @@ fn extract_properties(content: &str) -> HashMap<String, String> {
             Err(_) => return HashMap::new(),
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) => {
-                let name = e.local_name().as_ref().to_vec();
-                let parent = depth_stack.last().map(|v| v.as_slice());
+                let name = e.local_name().as_ref().to_string();
+                let parent = depth_stack.last().map(String::as_str);
                 // Properties map: project > properties > <key>
-                if parent == Some(b"properties")
+                if parent == Some("properties")
                     && depth_stack.len() >= 2
-                    && depth_stack[depth_stack.len() - 2] == b"project"
-                    && let Ok(s) = std::str::from_utf8(&name)
+                    && depth_stack[depth_stack.len() - 2] == "project"
                 {
-                    current_key = Some(s.to_string());
+                    current_key = Some(name.clone());
                 }
                 // Built-in project properties: project > (version|groupId|artifactId)
-                if parent == Some(b"project")
-                    && matches!(name.as_slice(), b"version" | b"groupId" | b"artifactId")
-                    && let Ok(s) = std::str::from_utf8(&name)
+                if parent == Some("project")
+                    && matches!(name.as_str(), "version" | "groupId" | "artifactId")
                 {
-                    current_key = Some(format!("project.{s}"));
+                    current_key = Some(format!("project.{name}"));
                 }
                 depth_stack.push(name);
             }
             Ok(Event::Text(e)) => {
                 if let Some(ref key) = current_key
-                    && let Ok(text) = e.decode()
                     && !out.contains_key(key)
                 {
                     // First occurrence wins to avoid overwriting project.version
                     // with a nested <dependency><version>.
-                    out.insert(key.clone(), text.into_owned());
+                    out.insert(key.clone(), e.to_string());
                 }
             }
             Ok(Event::End(_)) => {
@@ -176,7 +173,7 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
     let mut in_plugins = false;
     let mut in_dependency = false;
     let mut has_parent = false;
-    let mut current_tag: Option<Vec<u8>> = None;
+    let mut current_tag: Option<String> = None;
 
     // Current dependency accumulator
     let mut cur_group: Option<String> = None;
@@ -192,13 +189,13 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
             Err(_) => return vec![], // invalid XML → empty result
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) => {
-                let name = e.local_name().as_ref().to_vec();
-                match name.as_slice() {
-                    b"dependencies" if !in_plugins => in_dependencies = true,
-                    b"dependencyManagement" => in_dep_mgmt = true,
-                    b"plugins" | b"pluginManagement" => in_plugins = true,
-                    b"parent" => has_parent = true,
-                    b"dependency" if (in_dependencies || in_dep_mgmt) && !in_plugins => {
+                let name = e.local_name().as_ref().to_string();
+                match name.as_str() {
+                    "dependencies" if !in_plugins => in_dependencies = true,
+                    "dependencyManagement" => in_dep_mgmt = true,
+                    "plugins" | "pluginManagement" => in_plugins = true,
+                    "parent" => has_parent = true,
+                    "dependency" if (in_dependencies || in_dep_mgmt) && !in_plugins => {
                         in_dependency = true;
                         cur_group = None;
                         cur_artifact = None;
@@ -213,12 +210,12 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                 current_tag = Some(name);
             }
             Ok(Event::End(e)) => {
-                let name = e.local_name().as_ref().to_vec();
-                match name.as_slice() {
-                    b"dependencies" => in_dependencies = false,
-                    b"dependencyManagement" => in_dep_mgmt = false,
-                    b"plugins" | b"pluginManagement" => in_plugins = false,
-                    b"dependency" if in_dependency => {
+                let name = e.local_name().as_ref().to_string();
+                match name.as_str() {
+                    "dependencies" => in_dependencies = false,
+                    "dependencyManagement" => in_dep_mgmt = false,
+                    "plugins" | "pluginManagement" => in_plugins = false,
+                    "dependency" if in_dependency => {
                         in_dependency = false;
                         let g_opt = cur_group.take();
                         let a_opt = cur_artifact.take();
@@ -297,25 +294,22 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                 current_tag = None;
             }
             Ok(Event::Text(e)) if in_dependency => {
-                let raw = match e.decode() {
-                    Ok(s) => s.into_owned(),
-                    Err(_) => continue,
-                };
+                let raw = e.to_string();
                 let text = raw.trim().to_string();
                 match current_tag.as_deref() {
-                    Some(b"groupId") => cur_group = Some(text),
-                    Some(b"artifactId") => {
+                    Some("groupId") => cur_group = Some(text),
+                    Some("artifactId") => {
                         let (s, e_) = trimmed_span(bytes, &reader, raw.len());
                         cur_artifact_span = Some((s, e_));
                         cur_artifact = Some(text);
                     }
-                    Some(b"version") => {
+                    Some("version") => {
                         let (s, e_) = trimmed_span(bytes, &reader, raw.len());
                         cur_version_span = Some((s, e_));
                         cur_version = Some(text);
                     }
-                    Some(b"scope") => cur_scope = Some(text),
-                    Some(b"optional") => cur_optional = text == "true",
+                    Some("scope") => cur_scope = Some(text),
+                    Some("optional") => cur_optional = text == "true",
                     _ => {}
                 }
             }

--- a/depsy-lsp/src/registries/maven_central.rs
+++ b/depsy-lsp/src/registries/maven_central.rs
@@ -158,35 +158,32 @@ pub(crate) fn parse_metadata_xml(
     let mut release: Option<String> = None;
     let mut versions: Vec<String> = Vec::new();
 
-    let mut stack: Vec<Vec<u8>> = Vec::new();
+    let mut stack: Vec<String> = Vec::new();
 
     loop {
         match reader.read_event() {
             Err(_) => return None,
             Ok(Event::Eof) => break,
-            Ok(Event::Start(e)) => stack.push(e.name().as_ref().to_vec()),
+            Ok(Event::Start(e)) => stack.push(e.name().as_ref().to_string()),
             Ok(Event::End(_)) => {
                 stack.pop();
             }
             Ok(Event::Text(e)) => {
-                let text = match e.decode() {
-                    Ok(s) => s.into_owned(),
-                    Err(_) => continue,
-                };
+                let text = e.to_string();
                 // Path checks: metadata > versioning > latest | release
                 // Path: metadata > versioning > versions > version
                 let len = stack.len();
-                if len >= 3 && stack[len - 3] == b"metadata" && stack[len - 2] == b"versioning" {
-                    match stack[len - 1].as_slice() {
-                        b"latest" => latest = Some(text),
-                        b"release" => release = Some(text),
+                if len >= 3 && stack[len - 3] == "metadata" && stack[len - 2] == "versioning" {
+                    match stack[len - 1].as_str() {
+                        "latest" => latest = Some(text),
+                        "release" => release = Some(text),
                         _ => {}
                     }
                 } else if len >= 4
-                    && stack[len - 4] == b"metadata"
-                    && stack[len - 3] == b"versioning"
-                    && stack[len - 2] == b"versions"
-                    && stack[len - 1] == b"version"
+                    && stack[len - 4] == "metadata"
+                    && stack[len - 3] == "versioning"
+                    && stack[len - 2] == "versions"
+                    && stack[len - 1] == "version"
                 {
                     versions.push(text);
                 }
@@ -218,43 +215,40 @@ pub(crate) fn parse_pom_metadata(
     let mut repository: Option<String> = None;
     let mut licenses: Vec<String> = Vec::new();
 
-    let mut stack: Vec<Vec<u8>> = Vec::new();
+    let mut stack: Vec<String> = Vec::new();
 
     loop {
         match reader.read_event() {
             Err(_) => break,
             Ok(Event::Eof) => break,
-            Ok(Event::Start(e)) => stack.push(e.name().as_ref().to_vec()),
+            Ok(Event::Start(e)) => stack.push(e.name().as_ref().to_string()),
             Ok(Event::End(_)) => {
                 stack.pop();
             }
             Ok(Event::Text(e)) => {
-                let text = match e.decode() {
-                    Ok(s) => s.into_owned(),
-                    Err(_) => continue,
-                };
+                let text = e.to_string();
                 let len = stack.len();
                 // project > description
-                if len == 2 && stack[0] == b"project" && stack[1] == b"description" {
+                if len == 2 && stack[0] == "project" && stack[1] == "description" {
                     description = Some(text);
                     continue;
                 }
                 // project > url
-                if len == 2 && stack[0] == b"project" && stack[1] == b"url" {
+                if len == 2 && stack[0] == "project" && stack[1] == "url" {
                     homepage = Some(text);
                     continue;
                 }
                 // project > scm > url
-                if len == 3 && stack[0] == b"project" && stack[1] == b"scm" && stack[2] == b"url" {
+                if len == 3 && stack[0] == "project" && stack[1] == "scm" && stack[2] == "url" {
                     repository = Some(text);
                     continue;
                 }
                 // project > licenses > license > name
                 if len == 4
-                    && stack[0] == b"project"
-                    && stack[1] == b"licenses"
-                    && stack[2] == b"license"
-                    && stack[3] == b"name"
+                    && stack[0] == "project"
+                    && stack[1] == "licenses"
+                    && stack[2] == "license"
+                    && stack[3] == "name"
                 {
                     licenses.push(text);
                 }


### PR DESCRIPTION
Rolls up the open dependabot bumps into a single PR so the whole set gets one CI run and one review.

## Rust dependencies

| Crate | From | To |
|---|---|---|
| tokio | 1.52.3 | 1.53.1 |
| clap | 4.5.60 | 4.6.6 |
| serde | 1.0.228 | 1.0.229 |
| serde_json | 1.0.150 | 1.0.151 |
| anyhow | 1.0.103 | 1.0.104 |
| futures | 0.3.32 | 0.3.34 |
| quick-xml | 0.41.0 | 0.42.0 |
| serial_test | 3.5.0 | 4.0.1 |
| toml (lock) | 1.1.2+spec-1.1.0 | 1.1.4+spec-1.1.0 |
| rusqlite (lock) | 0.40.1 | 0.40.2 |
| async-trait (lock) | 0.1.89 | 0.1.92 |
| quinn-proto (fuzz lock) | 0.11.14 | 0.11.17 |

## GitHub Actions

- `actions/setup-node` v6 -> v7
- `CodSpeedHQ/action` v4 -> v5

## quick-xml 0.42 migration

This is the only bump that needed code changes. 0.42 decodes at the reader level, so:

- events expose `&str` instead of `&[u8]` (`local_name().as_ref()`, `Attribute::key`/`value`, `BytesStart`/`BytesText`/`BytesDecl`/`BytesRef` all `Deref<Target = str>`);
- `BytesText::decode()` is gone — the content is already decoded;
- `Attribute::decoded_and_normalized_value(version, decoder)` is replaced by `normalized_value(version)`.

Migrated in `parsers/maven.rs`, `registries/maven_central.rs` and `parsers/csharp.rs`. Tag/attribute matching moves from byte literals to string literals; the byte-offset arithmetic in `csharp.rs` (`event_content_start`, `located_text`, `attribute_value_range`) is untouched because `str::len` is still a byte length, so reported spans are identical.

`is_supported_xml_reference` also loses a fallible `decode()` step: `resolve_xml_entity` now takes the `&str` directly.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo doc --no-deps`: clean
- `cargo test`: 911 passed, 0 failed, 21 ignored (same set as `main` — no test files changed)
- `cargo audit`: no advisories over 352 crates
- `cargo +nightly check` in `depsy-lsp/fuzz`: clean
- `cargo build --release --target wasm32-wasip1` in `depsy-zed`: clean

## Supersedes

Closes #357, #371, #380, #381, #382, #383, #384, #385, #386, #387, #388, #389, #390.

The `dependi-lsp/` dependabot PRs (#363, #364, #365, #367, #368, #369, #370, #373, #374, #375, #376) were closed separately — that directory was renamed to `depsy-lsp/` in #379, so they could not be rebased.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls up open dependabot bumps into one PR so the whole set gets a single CI run and review, updating Rust crates (tokio, clap, serde, serde_json, anyhow, futures, serial_test, quick-xml, plus lockfile refreshes) and GitHub Actions (`actions/setup-node` v7, `CodSpeedHQ/action` v5). The only code changes come from `quick-xml` 0.42, which decodes at the reader level; all behavior and reported spans stay the same.

**Migration**

- `quick-xml` 0.42 events expose `&str` instead of `&[u8]` — `local_name()`, `Attribute::key`/`value`, and `BytesStart`/`BytesText`/`BytesDecl`/`BytesRef` all dereference to `str`.
- `BytesText::decode()` is removed; content comes pre-decoded.
- `Attribute::decoded_and_normalized_value(...)` is replaced by `normalized_value(...)`.
- Maven, Maven Central, and NuGet parsers now match string literals instead of byte literals; byte-offset arithmetic is untouched since `str::len` measures bytes.

<sup>Written for commit 0d445ea53e348b0b5144afb2879f22208f352834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/zed-depsy/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C# and Maven XML parsing for more consistent handling of text, tags, attributes, encodings, and entity references.
  * Prevented valid text content from being skipped during dependency metadata processing.

* **Chores**
  * Refreshed Rust dependencies and updated automated validation and benchmarking tools.

* **Documentation**
  * Added an Unreleased changelog entry summarizing the updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->