### PR TITLE
fix(maven): assemble XML text split by entity references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spans cover the whole value. Numeric character references (`&#45;`) resolve as
   well; an entity that cannot be resolved is kept as written rather than dropped
   ([#394](https://github.com/mpiton/zed-depsy/issues/394))
+- A `<![CDATA[...]]>` section inside a pom value is part of that value again,
+  in the pom parser, `maven-metadata.xml` and the pom metadata used for hover.
+  It was dropped and only the surrounding text survived.
+- An `<exclusions>` block no longer renames the dependency that declares it.
+  `<exclusion>` repeats `<groupId>` and `<artifactId>` for the artifact being
+  excluded, and the parser committed those over the dependency's own
+  coordinates, so hover, diagnostics and the update quick-fix all pointed at the
+  excluded artifact. Only direct children of `<dependency>` are read now.
+- A `<dependency>` whose `groupId`, `artifactId` or `version` the parser cannot
+  read as written is skipped rather than reported under a value it made up. This
+  covers a DTD-declared entity (`<version>&ver;</version>`, which would have
+  been queried against Maven Central verbatim), a value interrupted by a comment
+  (`<version>1.<!-- why -->7.30</version>`, which has no contiguous range for
+  the update quick-fix to overwrite), a value written across two lines, and a
+  `<version>` holding only whitespace. A comment placed *after* the value, as in
+  `<version>1.7.30<!-- pinned --></version>`, is unaffected.
 - A `Cargo.lock` holding several versions of the same crate no longer resolves
   to whichever entry appears first: the entry is matched against the
   requirement declared in `Cargo.toml`, so `serde = "~1.1"` no longer reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `maven-metadata.xml` and the pom metadata used for hover, and the reported
   spans cover the whole value. Numeric character references (`&#45;`) resolve as
   well; an entity that cannot be resolved is kept as written rather than dropped
+  in free text such as `<description>` and `<url>`
   ([#394](https://github.com/mpiton/zed-depsy/issues/394))
 - A `<![CDATA[...]]>` section inside a pom value is part of that value again,
   in the pom parser, `maven-metadata.xml` and the pom metadata used for hover.
@@ -44,6 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the update quick-fix to overwrite), a value written across two lines, and a
   `<version>` holding only whitespace. A comment placed *after* the value, as in
   `<version>1.7.30<!-- pinned --></version>`, is unaffected.
+- A `<properties>` entry holding an entity the parser cannot resolve is dropped
+  instead of being substituted into a coordinate. `<ver>&custom;</ver>` paired
+  with `<version>${ver}</version>` reported the dependency at version
+  `&custom;`, which was then queried against Maven Central; `${ver}` now stays
+  unsubstituted, the same as a property that was never declared.
 - A `Cargo.lock` holding several versions of the same crate no longer resolves
   to whichever entry appears first: the entry is matched against the
   requirement declared in `Cargo.toml`, so `serde = "~1.1"` no longer reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Maven XML values containing an entity reference are no longer truncated.
+  quick-xml reports `&amp;` as its own event between two text events, and the
+  Maven parsers kept a single fragment instead of joining them, so
+  `<description>Fast &amp; small</description>` surfaced as `small` in hover.
+  Element text is now assembled across fragments in the pom parser,
+  `maven-metadata.xml` and the pom metadata used for hover, and the reported
+  spans cover the whole value. Numeric character references (`&#45;`) resolve as
+  well; an entity that cannot be resolved is kept as written rather than dropped
+  ([#394](https://github.com/mpiton/zed-depsy/issues/394))
 - A `Cargo.lock` holding several versions of the same crate no longer resolves
   to whichever entry appears first: the entry is matched against the
   requirement declared in `Cargo.toml`, so `serde = "~1.1"` no longer reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with `<version>${ver}</version>` reported the dependency at version
   `&custom;`, which was then queried against Maven Central; `${ver}` now stays
   unsubstituted, the same as a property that was never declared.
+- A version in `maven-metadata.xml` holding an entity the parser cannot resolve
+  is dropped instead of being interpolated into the pom URL. `<release>` and
+  each `<version>` end up in `{base}/{group}/{artifact}/{v}/{artifact}-{v}.pom`,
+  so the literal `&name;` became a request and was reported as the latest
+  version.
+- A `<dependency>` whose `<artifactId>` has no range on a single line is skipped
+  rather than reported with a name span on line 0, which is where hover, the
+  document link and the diagnostic were anchored. Applies to an artifactId
+  written across two lines or interrupted by a comment, matching the rule
+  already in place for `<version>`.
 - A `Cargo.lock` holding several versions of the same crate no longer resolves
   to whichever entry appears first: the entry is matched against the
   requirement declared in `Cargo.toml`, so `serde = "~1.1"` no longer reports

--- a/depsy-lsp/src/parsers/maven.rs
+++ b/depsy-lsp/src/parsers/maven.rs
@@ -124,6 +124,10 @@ fn extract_properties(content: &str) -> HashMap<String, String> {
     // Text of the element being read, assembled across the `Text` / `GeneralRef`
     // fragments quick-xml emits for a single value.
     let mut text = String::new();
+    // A value holding a reference we cannot resolve is not what the pom declares.
+    // Dropping the property leaves `${key}` unsubstituted, the same as a key that
+    // was never defined, instead of feeding `&name;` to a coordinate.
+    let mut unresolved = false;
 
     loop {
         match reader.read_event() {
@@ -131,6 +135,7 @@ fn extract_properties(content: &str) -> HashMap<String, String> {
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) => {
                 text.clear();
+                unresolved = false;
                 let name = e.local_name().as_ref().to_string();
                 let parent = depth_stack.last().map(String::as_str);
                 // Properties map: project > properties > <key>
@@ -152,13 +157,14 @@ fn extract_properties(content: &str) -> HashMap<String, String> {
             // CDATA carries the value literally, entity references included.
             Ok(Event::CData(e)) if current_key.is_some() => text.push_str(&e),
             Ok(Event::GeneralRef(e)) if current_key.is_some() => {
-                push_xml_ref(&mut text, &e);
+                unresolved |= !push_xml_ref(&mut text, &e);
             }
             Ok(Event::End(_)) => {
                 let value = text.trim();
                 // First occurrence wins to avoid overwriting project.version
                 // with a nested <dependency><version>.
                 if let Some(key) = current_key.take()
+                    && !unresolved
                     && !value.is_empty()
                     && !out.contains_key(&key)
                 {
@@ -166,6 +172,7 @@ fn extract_properties(content: &str) -> HashMap<String, String> {
                 }
                 depth_stack.pop();
                 text.clear();
+                unresolved = false;
             }
             _ => {}
         }
@@ -1168,17 +1175,39 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_entity_kept_verbatim() {
+    fn test_property_with_unknown_entity_is_dropped() {
         let pom = r#"<project>
     <properties>
         <odd>a&custom;b</odd>
     </properties>
 </project>"#;
         let props = extract_properties(pom);
-        assert_eq!(
-            props.get("odd").map(String::as_str),
-            Some("a&custom;b"),
-            "an entity we cannot resolve is kept as written rather than dropped"
+        assert!(
+            !props.contains_key("odd"),
+            "a property we cannot read as written must not reach substitution"
         );
+    }
+
+    #[test]
+    fn test_unknown_entity_in_property_does_not_reach_the_version() {
+        let pom = r#"<project>
+    <properties>
+        <lib.version>&custom;</lib.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>lib</artifactId>
+            <version>${lib.version}</version>
+        </dependency>
+    </dependencies>
+</project>"#;
+        let deps = MavenParser::new().parse(pom);
+        assert_eq!(deps.len(), 1);
+        // The placeholder stays unsubstituted, exactly as for an undefined key, so
+        // `&custom;` never becomes the version sent to Maven Central.
+        assert_eq!(deps[0].version, "${lib.version}");
+        assert_eq!(deps[0].resolved_version, None);
+        assert_eq!(deps[0].effective_version(), "${lib.version}");
     }
 }

--- a/depsy-lsp/src/parsers/maven.rs
+++ b/depsy-lsp/src/parsers/maven.rs
@@ -12,6 +12,11 @@
 //! - Parent POM inheritance
 //! - BOM (`<scope>import</scope>`) resolution from remote POMs
 //! - Plugin dependencies
+//! - DTD-declared entities (`<!ENTITY ver "1.0">`): a coordinate that uses one
+//!   cannot be expanded, so the whole dependency is skipped rather than
+//!   reported under the literal `&ver;`
+//! - A coordinate written across two source lines: [`Span`] addresses a single
+//!   line, so such a declaration is skipped too
 
 use hashbrown::HashMap;
 use quick_xml::events::Event;
@@ -144,7 +149,11 @@ fn extract_properties(content: &str) -> HashMap<String, String> {
                 depth_stack.push(name);
             }
             Ok(Event::Text(e)) if current_key.is_some() => text.push_str(&e),
-            Ok(Event::GeneralRef(e)) if current_key.is_some() => push_xml_ref(&mut text, &e),
+            // CDATA carries the value literally, entity references included.
+            Ok(Event::CData(e)) if current_key.is_some() => text.push_str(&e),
+            Ok(Event::GeneralRef(e)) if current_key.is_some() => {
+                push_xml_ref(&mut text, &e);
+            }
             Ok(Event::End(_)) => {
                 let value = text.trim();
                 // First occurrence wins to avoid overwriting project.version
@@ -181,9 +190,14 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
     let mut in_dependencies = false;
     let mut in_dep_mgmt = false;
     let mut in_plugins = false;
-    let mut in_dependency = false;
     let mut has_parent = false;
-    let mut current_tag: Option<String> = None;
+
+    // Nesting level of the element currently being read, and the level of the
+    // open `<dependency>`. Only elements one level below it carry the
+    // dependency's own coordinates: `<exclusions><exclusion><groupId>` names the
+    // artifact being excluded, not this one.
+    let mut depth = 0usize;
+    let mut dep_depth: Option<usize> = None;
 
     // Current dependency accumulator
     let mut cur_group: Option<String> = None;
@@ -195,9 +209,14 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
     let mut cur_optional = false;
 
     // Text of the element being read plus its byte span, assembled across the
-    // `Text` / `GeneralRef` fragments quick-xml emits for a single value.
+    // `Text` / `CData` / `GeneralRef` fragments quick-xml emits for a single
+    // value. `text_unresolved` records that one of those fragments was a
+    // reference the parser could not expand; `text_gapped` that something which
+    // is not part of the value sits between two of them.
     let mut text = String::new();
     let mut text_span: Option<(usize, usize)> = None;
+    let mut text_unresolved = false;
+    let mut text_gapped = false;
 
     loop {
         // Position before the event is the start offset of its raw bytes.
@@ -208,14 +227,20 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
             Ok(Event::Start(e)) => {
                 text.clear();
                 text_span = None;
-                let name = e.local_name().as_ref().to_string();
-                match name.as_str() {
+                text_unresolved = false;
+                text_gapped = false;
+                depth += 1;
+                match e.local_name().as_ref() {
                     "dependencies" if !in_plugins => in_dependencies = true,
                     "dependencyManagement" => in_dep_mgmt = true,
                     "plugins" | "pluginManagement" => in_plugins = true,
                     "parent" => has_parent = true,
-                    "dependency" if (in_dependencies || in_dep_mgmt) && !in_plugins => {
-                        in_dependency = true;
+                    "dependency"
+                        if (in_dependencies || in_dep_mgmt)
+                            && !in_plugins
+                            && dep_depth.is_none() =>
+                    {
+                        dep_depth = Some(depth);
                         cur_group = None;
                         cur_artifact = None;
                         cur_artifact_span = None;
@@ -226,42 +251,58 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                     }
                     _ => {}
                 }
-                current_tag = Some(name);
             }
             Ok(Event::End(e)) => {
+                let local = e.local_name();
+                let name = local.as_ref();
+
                 // Commit the element text before `</dependency>` clears the
-                // per-dependency state below.
-                if in_dependency {
+                // per-dependency state below. Only a direct child of
+                // `<dependency>` counts, so an `<exclusion>` cannot overwrite
+                // the coordinates of the dependency that excludes it.
+                if dep_depth.is_some_and(|d| d + 1 == depth) {
                     let value = text.trim();
+                    // A span only addresses a contiguous run of source bytes. If
+                    // a comment sat between two fragments the span would cover
+                    // it too, and the "update version" quick-fix writes over
+                    // whatever the span covers.
+                    let usable_span = if text_gapped { None } else { text_span };
                     if !value.is_empty() {
-                        match current_tag.as_deref() {
-                            Some("groupId") => cur_group = Some(value.to_string()),
-                            Some("artifactId") => {
+                        match name {
+                            // A reference the parser could not expand leaves a
+                            // literal `&name;` in the value. That is fine for
+                            // prose, but a coordinate built from it would query
+                            // the registry for something the pom never named, so
+                            // the field is left unset and the dependency is
+                            // dropped further down.
+                            "groupId" if !text_unresolved => cur_group = Some(value.to_string()),
+                            "artifactId" if !text_unresolved => {
                                 cur_artifact_span =
-                                    text_span.map(|(s, e_)| trimmed_span(bytes, s, e_));
+                                    usable_span.map(|(s, e_)| trimmed_span(bytes, s, e_));
                                 cur_artifact = Some(value.to_string());
                             }
-                            Some("version") => {
+                            "version" if !text_unresolved => {
                                 cur_version_span =
-                                    text_span.map(|(s, e_)| trimmed_span(bytes, s, e_));
+                                    usable_span.map(|(s, e_)| trimmed_span(bytes, s, e_));
                                 cur_version = Some(value.to_string());
                             }
-                            Some("scope") => cur_scope = Some(value.to_string()),
-                            Some("optional") => cur_optional = value == "true",
+                            "scope" => cur_scope = Some(value.to_string()),
+                            "optional" => cur_optional = value == "true",
                             _ => {}
                         }
                     }
                 }
                 text.clear();
                 text_span = None;
+                text_unresolved = false;
+                text_gapped = false;
 
-                let name = e.local_name().as_ref().to_string();
-                match name.as_str() {
+                match name {
                     "dependencies" => in_dependencies = false,
                     "dependencyManagement" => in_dep_mgmt = false,
                     "plugins" | "pluginManagement" => in_plugins = false,
-                    "dependency" if in_dependency => {
-                        in_dependency = false;
+                    "dependency" if dep_depth == Some(depth) => {
+                        dep_depth = None;
                         let g_opt = cur_group.take();
                         let a_opt = cur_artifact.take();
                         let raw_version = cur_version.take().unwrap_or_default();
@@ -277,6 +318,7 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                         if let (Some(g), Some(a), Some((vs, ve))) = (g_opt, a_opt, version_span_raw)
                             && !g.is_empty()
                             && !a.is_empty()
+                            && let Some(version_span) = single_line_span(&offsets, vs, ve)
                         {
                             let dev = scope == "test" || scope == "provided";
                             let resolved = substitute(&raw_version, properties);
@@ -296,30 +338,13 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                                     (resolved, None)
                                 };
 
-                            let (line, line_start) = offset_to_position(&offsets, vs);
-                            let (_, line_end) = offset_to_position(&offsets, ve);
-                            let version_span = Span {
-                                line,
-                                line_start,
-                                line_end,
-                            };
-
-                            let name_span = match artifact_span {
-                                Some((s, e_)) => {
-                                    let (line, line_start) = offset_to_position(&offsets, s);
-                                    let (_, line_end) = offset_to_position(&offsets, e_);
-                                    Span {
-                                        line,
-                                        line_start,
-                                        line_end,
-                                    }
-                                }
-                                None => Span {
+                            let name_span = artifact_span
+                                .and_then(|(s, e_)| single_line_span(&offsets, s, e_))
+                                .unwrap_or(Span {
                                     line: 0,
                                     line_start: 0,
                                     line_end: 0,
-                                },
-                            };
+                                });
 
                             out.push(Dependency {
                                 name: format!("{g}:{a}"),
@@ -336,17 +361,37 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                     }
                     _ => {}
                 }
-                current_tag = None;
+                depth = depth.saturating_sub(1);
             }
-            Ok(Event::Text(e)) if in_dependency => {
+            Ok(Event::Text(e)) if dep_depth.is_some() => {
                 text.push_str(&e);
-                let start = text_span.map_or(event_start, |(s, _)| s);
-                text_span = Some((start, reader.buffer_position() as usize));
+                extend_span(
+                    &mut text_span,
+                    &mut text_gapped,
+                    event_start,
+                    reader.buffer_position() as usize,
+                );
             }
-            Ok(Event::GeneralRef(e)) if in_dependency => {
-                push_xml_ref(&mut text, &e);
-                let start = text_span.map_or(event_start, |(s, _)| s);
-                text_span = Some((start, reader.buffer_position() as usize));
+            // CDATA carries the value literally, entity references included.
+            Ok(Event::CData(e)) if dep_depth.is_some() => {
+                text.push_str(&e);
+                extend_span(
+                    &mut text_span,
+                    &mut text_gapped,
+                    event_start,
+                    reader.buffer_position() as usize,
+                );
+            }
+            Ok(Event::GeneralRef(e)) if dep_depth.is_some() => {
+                if !push_xml_ref(&mut text, &e) {
+                    text_unresolved = true;
+                }
+                extend_span(
+                    &mut text_span,
+                    &mut text_gapped,
+                    event_start,
+                    reader.buffer_position() as usize,
+                );
             }
             _ => {}
         }
@@ -359,6 +404,40 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
         );
     }
     out
+}
+
+/// Extends `span` to cover the value fragment starting at `start`.
+///
+/// quick-xml hands a single element value over as several events — text runs
+/// split by each entity reference or CDATA section — so the span grows one
+/// fragment at a time, from `start` to `end`. `gapped` is raised when a fragment
+/// does not begin where the previous one ended: something the value does not
+/// contain sits in between, a comment or a processing instruction, and a span
+/// drawn over the whole run would cover that too.
+fn extend_span(span: &mut Option<(usize, usize)>, gapped: &mut bool, start: usize, end: usize) {
+    match *span {
+        Some((first, prev_end)) => {
+            *gapped |= prev_end != start;
+            *span = Some((first, end));
+        }
+        None => *span = Some((start, end)),
+    }
+}
+
+/// Builds a [`Span`] for `start..end`, or `None` if it straddles a line break.
+///
+/// [`Span`] covers a range within a single line, so a value written across two
+/// lines has no representation: measuring the end offset's column against the
+/// start line would report a range that ends before it starts. Callers drop the
+/// declaration instead of handing the editor a reversed range.
+fn single_line_span(offsets: &[usize], start: usize, end: usize) -> Option<Span> {
+    let (line, line_start) = offset_to_position(offsets, start);
+    let (end_line, line_end) = offset_to_position(offsets, end);
+    (end_line == line).then_some(Span {
+        line,
+        line_start,
+        line_end,
+    })
 }
 
 /// Narrows the byte span `start..end` to its non-whitespace content.
@@ -530,6 +609,177 @@ mod tests {
 "#;
         let deps = parser.parse(pom);
         assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn test_parse_whitespace_only_version_is_skipped() {
+        // Same rule as a missing <version>: nothing usable to diagnose or update.
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0"?>
+<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>   </version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        let deps = parser.parse(pom);
+        assert!(deps.is_empty(), "a blank <version> carries no version");
+    }
+
+    #[test]
+    fn test_parse_trailing_comment_keeps_version_and_span() {
+        // A comment after the value does not interrupt it, so the span still
+        // covers exactly the version and the quick-fix stays usable.
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0"?>
+<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30<!-- pinned by ops --></version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        let deps = parser.parse(pom);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].version, "1.7.30");
+        let line = pom.lines().nth(deps[0].version_span.line as usize).unwrap();
+        let start = deps[0].version_span.line_start as usize;
+        let end = deps[0].version_span.line_end as usize;
+        assert_eq!(
+            &line[start..end],
+            "1.7.30",
+            "span must stop before the comment"
+        );
+    }
+
+    #[test]
+    fn test_parse_comment_splitting_version_is_skipped() {
+        // XML says the value is the two runs joined, but no single range of
+        // source bytes holds it: a span would cover the comment, and the "update
+        // version" quick-fix writes over whatever the span covers.
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0"?>
+<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.<!-- why -->7.30</version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        let deps = parser.parse(pom);
+        assert!(
+            deps.is_empty(),
+            "an interrupted value has no span to anchor an edit"
+        );
+    }
+
+    #[test]
+    fn test_parse_cdata_inside_version_is_kept() {
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0"?>
+<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.<![CDATA[7]]>30</version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        let deps = parser.parse(pom);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(
+            deps[0].version, "1.730",
+            "CDATA content is part of the value"
+        );
+    }
+
+    #[test]
+    fn test_parse_exclusions_do_not_overwrite_coordinates() {
+        // <exclusion> repeats <groupId>/<artifactId> for the artifact being
+        // excluded; only direct children of <dependency> name the dependency.
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0"?>
+<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>6.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        let deps = parser.parse(pom);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].name, "org.springframework:spring-core");
+        assert_eq!(deps[0].version, "6.1.0");
+        let line = pom.lines().nth(deps[0].name_span.line as usize).unwrap();
+        assert!(
+            line.contains("spring-core"),
+            "name_span points at the exclusion instead of the dependency: {line}"
+        );
+    }
+
+    #[test]
+    fn test_parse_unresolvable_entity_in_coordinate_is_skipped() {
+        // quick-xml does not expand DTD-declared entities, so `&ver;` reaches the
+        // parser verbatim. Reporting it would send `&ver;` to Maven Central.
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0"?>
+<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>&ver;</version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        let deps = parser.parse(pom);
+        assert!(deps.is_empty(), "an unexpanded entity is not a version");
+    }
+
+    #[test]
+    fn test_parse_version_across_two_lines_is_skipped() {
+        // `Span` addresses one line; reporting the end column against the start
+        // line would hand the editor a range that ends before it starts.
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0"?>
+<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7&amp;
+30</version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        let deps = parser.parse(pom);
+        assert!(
+            deps.is_empty(),
+            "a multi-line value has no single-line span"
+        );
     }
 
     #[test]

--- a/depsy-lsp/src/parsers/maven.rs
+++ b/depsy-lsp/src/parsers/maven.rs
@@ -326,6 +326,11 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                             && !g.is_empty()
                             && !a.is_empty()
                             && let Some(version_span) = single_line_span(&offsets, vs, ve)
+                            // Same rule for the name: without a range on one line
+                            // there is nothing to anchor hover, the document link or
+                            // the diagnostic to, and line 0 is not that place.
+                            && let Some(name_span) = artifact_span
+                                .and_then(|(s, e_)| single_line_span(&offsets, s, e_))
                         {
                             let dev = scope == "test" || scope == "provided";
                             let resolved = substitute(&raw_version, properties);
@@ -344,14 +349,6 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                                 } else {
                                     (resolved, None)
                                 };
-
-                            let name_span = artifact_span
-                                .and_then(|(s, e_)| single_line_span(&offsets, s, e_))
-                                .unwrap_or(Span {
-                                    line: 0,
-                                    line_start: 0,
-                                    line_end: 0,
-                                });
 
                             out.push(Dependency {
                                 name: format!("{g}:{a}"),
@@ -786,6 +783,44 @@ mod tests {
         assert!(
             deps.is_empty(),
             "a multi-line value has no single-line span"
+        );
+    }
+
+    #[test]
+    fn test_parse_artifact_id_without_usable_span_is_skipped() {
+        // The name span anchors hover, the document link and the diagnostic. When
+        // it cannot be built the dependency used to be emitted anyway, pointing at
+        // line 0.
+        let parser = MavenParser::new();
+        let across_lines = r#"<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-
+api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        assert!(
+            parser.parse(across_lines).is_empty(),
+            "an artifactId written across two lines has no single-line span"
+        );
+
+        let interrupted = r#"<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j<!-- renamed -->-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        assert!(
+            parser.parse(interrupted).is_empty(),
+            "an artifactId interrupted by a comment has no contiguous span"
         );
     }
 

--- a/depsy-lsp/src/parsers/maven.rs
+++ b/depsy-lsp/src/parsers/maven.rs
@@ -18,6 +18,7 @@ use quick_xml::events::Event;
 use quick_xml::reader::Reader;
 
 use crate::parsers::{Dependency, Parser, Span};
+use crate::utils::push_xml_ref;
 
 /// Parser for Maven `pom.xml` files.
 ///
@@ -107,17 +108,24 @@ fn offset_to_position(offsets: &[usize], byte_offset: usize) -> (u32, u32) {
 /// subset of Maven's built-in property resolution that the MVP supports.
 fn extract_properties(content: &str) -> HashMap<String, String> {
     let mut reader = Reader::from_str(content);
-    reader.config_mut().trim_text(true);
+    // Keep the raw text: `trim_text(true)` trims each fragment of a value split by
+    // an entity reference on its own, which would eat the spaces around `&amp;`.
+    // The assembled value is trimmed on `End` instead.
+    reader.config_mut().trim_text(false);
 
     let mut out = HashMap::new();
     let mut depth_stack: Vec<String> = Vec::new();
     let mut current_key: Option<String> = None;
+    // Text of the element being read, assembled across the `Text` / `GeneralRef`
+    // fragments quick-xml emits for a single value.
+    let mut text = String::new();
 
     loop {
         match reader.read_event() {
             Err(_) => return HashMap::new(),
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) => {
+                text.clear();
                 let name = e.local_name().as_ref().to_string();
                 let parent = depth_stack.last().map(String::as_str);
                 // Properties map: project > properties > <key>
@@ -135,18 +143,20 @@ fn extract_properties(content: &str) -> HashMap<String, String> {
                 }
                 depth_stack.push(name);
             }
-            Ok(Event::Text(e)) => {
-                if let Some(ref key) = current_key
-                    && !out.contains_key(key)
-                {
-                    // First occurrence wins to avoid overwriting project.version
-                    // with a nested <dependency><version>.
-                    out.insert(key.clone(), e.to_string());
-                }
-            }
+            Ok(Event::Text(e)) if current_key.is_some() => text.push_str(&e),
+            Ok(Event::GeneralRef(e)) if current_key.is_some() => push_xml_ref(&mut text, &e),
             Ok(Event::End(_)) => {
+                let value = text.trim();
+                // First occurrence wins to avoid overwriting project.version
+                // with a nested <dependency><version>.
+                if let Some(key) = current_key.take()
+                    && !value.is_empty()
+                    && !out.contains_key(&key)
+                {
+                    out.insert(key, value.to_string());
+                }
                 depth_stack.pop();
-                current_key = None;
+                text.clear();
             }
             _ => {}
         }
@@ -184,11 +194,20 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
     let mut cur_scope: Option<String> = None;
     let mut cur_optional = false;
 
+    // Text of the element being read plus its byte span, assembled across the
+    // `Text` / `GeneralRef` fragments quick-xml emits for a single value.
+    let mut text = String::new();
+    let mut text_span: Option<(usize, usize)> = None;
+
     loop {
+        // Position before the event is the start offset of its raw bytes.
+        let event_start = reader.buffer_position() as usize;
         match reader.read_event() {
             Err(_) => return vec![], // invalid XML → empty result
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) => {
+                text.clear();
+                text_span = None;
                 let name = e.local_name().as_ref().to_string();
                 match name.as_str() {
                     "dependencies" if !in_plugins => in_dependencies = true,
@@ -210,6 +229,32 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                 current_tag = Some(name);
             }
             Ok(Event::End(e)) => {
+                // Commit the element text before `</dependency>` clears the
+                // per-dependency state below.
+                if in_dependency {
+                    let value = text.trim();
+                    if !value.is_empty() {
+                        match current_tag.as_deref() {
+                            Some("groupId") => cur_group = Some(value.to_string()),
+                            Some("artifactId") => {
+                                cur_artifact_span =
+                                    text_span.map(|(s, e_)| trimmed_span(bytes, s, e_));
+                                cur_artifact = Some(value.to_string());
+                            }
+                            Some("version") => {
+                                cur_version_span =
+                                    text_span.map(|(s, e_)| trimmed_span(bytes, s, e_));
+                                cur_version = Some(value.to_string());
+                            }
+                            Some("scope") => cur_scope = Some(value.to_string()),
+                            Some("optional") => cur_optional = value == "true",
+                            _ => {}
+                        }
+                    }
+                }
+                text.clear();
+                text_span = None;
+
                 let name = e.local_name().as_ref().to_string();
                 match name.as_str() {
                     "dependencies" => in_dependencies = false,
@@ -294,24 +339,14 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
                 current_tag = None;
             }
             Ok(Event::Text(e)) if in_dependency => {
-                let raw = e.to_string();
-                let text = raw.trim().to_string();
-                match current_tag.as_deref() {
-                    Some("groupId") => cur_group = Some(text),
-                    Some("artifactId") => {
-                        let (s, e_) = trimmed_span(bytes, &reader, raw.len());
-                        cur_artifact_span = Some((s, e_));
-                        cur_artifact = Some(text);
-                    }
-                    Some("version") => {
-                        let (s, e_) = trimmed_span(bytes, &reader, raw.len());
-                        cur_version_span = Some((s, e_));
-                        cur_version = Some(text);
-                    }
-                    Some("scope") => cur_scope = Some(text),
-                    Some("optional") => cur_optional = text == "true",
-                    _ => {}
-                }
+                text.push_str(&e);
+                let start = text_span.map_or(event_start, |(s, _)| s);
+                text_span = Some((start, reader.buffer_position() as usize));
+            }
+            Ok(Event::GeneralRef(e)) if in_dependency => {
+                push_xml_ref(&mut text, &e);
+                let start = text_span.map_or(event_start, |(s, _)| s);
+                text_span = Some((start, reader.buffer_position() as usize));
             }
             _ => {}
         }
@@ -326,13 +361,13 @@ fn extract_dependencies(content: &str, properties: &HashMap<String, String>) -> 
     out
 }
 
-/// Given the raw buffer position after a `Text` event and the raw text length,
-/// return the byte span of the trimmed content (leading + trailing whitespace removed).
-fn trimmed_span(bytes: &[u8], reader: &Reader<&[u8]>, raw_len: usize) -> (usize, usize) {
-    let raw_end = reader.buffer_position() as usize;
-    let raw_start = raw_end.saturating_sub(raw_len);
-    let mut start = raw_start.min(bytes.len());
-    let mut end = raw_end.min(bytes.len());
+/// Narrows the byte span `start..end` to its non-whitespace content.
+///
+/// The span covers the element's raw source, entity references included, so
+/// `<version>3.1&amp;4</version>` reports the whole `3.1&amp;4` run.
+fn trimmed_span(bytes: &[u8], start: usize, end: usize) -> (usize, usize) {
+    let mut start = start.min(bytes.len());
+    let mut end = end.min(bytes.len());
     while start < end && bytes[start].is_ascii_whitespace() {
         start += 1;
     }
@@ -768,6 +803,132 @@ mod tests {
             deps[0].resolved_version.as_deref(),
             Some("1.7.30"),
             "property substitution should work under prefixed namespace"
+        );
+    }
+
+    #[test]
+    fn test_parse_dependency_with_entity_references() {
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.a&amp;b</groupId>
+            <artifactId>art&amp;fact</artifactId>
+            <version>3.1&amp;4</version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        let deps = parser.parse(pom);
+        assert_eq!(deps.len(), 1, "should parse one dependency");
+        assert_eq!(
+            deps[0].name, "org.a&b:art&fact",
+            "entity references must be resolved and concatenated, not truncated"
+        );
+        assert_eq!(deps[0].version, "3.1&4");
+    }
+
+    #[test]
+    fn test_entity_reference_spans_cover_whole_value() {
+        let parser = MavenParser::new();
+        let pom = "<project>\n<dependencies>\n<dependency>\n<groupId>g</groupId>\n<artifactId>art&amp;fact</artifactId>\n<version>3.1&amp;4</version>\n</dependency>\n</dependencies>\n</project>\n";
+        let deps = parser.parse(pom);
+        assert_eq!(deps.len(), 1);
+        let lines: Vec<&str> = pom.lines().collect();
+
+        let ns = &deps[0].name_span;
+        assert_eq!(ns.line, 4, "artifactId is on line 4 (0-indexed)");
+        assert_eq!(
+            &lines[ns.line as usize][ns.line_start as usize..ns.line_end as usize],
+            "art&amp;fact",
+            "name span must cover the whole raw value, entity included"
+        );
+
+        let vs = &deps[0].version_span;
+        assert_eq!(vs.line, 5, "version is on line 5 (0-indexed)");
+        assert_eq!(
+            &lines[vs.line as usize][vs.line_start as usize..vs.line_end as usize],
+            "3.1&amp;4",
+            "version span must cover the whole raw value, entity included"
+        );
+    }
+
+    #[test]
+    fn test_parse_dependency_with_numeric_char_ref() {
+        let parser = MavenParser::new();
+        let pom = r#"<project>
+    <dependencies>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>lib</artifactId>
+            <version>1.0&#45;beta</version>
+        </dependency>
+    </dependencies>
+</project>"#;
+        let deps = parser.parse(pom);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].version, "1.0-beta", "numeric char refs resolve too");
+    }
+
+    #[test]
+    fn test_extract_properties_with_entity_reference() {
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <properties>
+        <docs.url>https://ex.com/?a=1&amp;b=2</docs.url>
+        <spaced.name>Fast &amp; small</spaced.name>
+    </properties>
+</project>
+"#;
+        let props = extract_properties(pom);
+        assert_eq!(
+            props.get("docs.url").map(String::as_str),
+            Some("https://ex.com/?a=1&b=2"),
+            "property values must keep the text around the entity reference"
+        );
+        assert_eq!(
+            props.get("spaced.name").map(String::as_str),
+            Some("Fast & small"),
+            "spaces around the entity must survive"
+        );
+    }
+
+    #[test]
+    fn test_property_substitution_with_entity_reference() {
+        let parser = MavenParser::new();
+        let pom = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <properties>
+        <lib.version>1.0&amp;2</lib.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>lib</artifactId>
+            <version>${lib.version}</version>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+        let deps = parser.parse(pom);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].version, "${lib.version}");
+        assert_eq!(deps[0].resolved_version.as_deref(), Some("1.0&2"));
+    }
+
+    #[test]
+    fn test_unknown_entity_kept_verbatim() {
+        let pom = r#"<project>
+    <properties>
+        <odd>a&custom;b</odd>
+    </properties>
+</project>"#;
+        let props = extract_properties(pom);
+        assert_eq!(
+            props.get("odd").map(String::as_str),
+            Some("a&custom;b"),
+            "an entity we cannot resolve is kept as written rather than dropped"
         );
     }
 }

--- a/depsy-lsp/src/registries/maven_central.rs
+++ b/depsy-lsp/src/registries/maven_central.rs
@@ -165,6 +165,10 @@ pub(crate) fn parse_metadata_xml(
     // Text of the element being read, assembled across the `Text` / `GeneralRef`
     // fragments quick-xml emits for a single value.
     let mut text = String::new();
+    // Every value this function keeps is a version, and `get_version_info` puts it
+    // straight into the pom URL. A reference we cannot resolve is not a version, so
+    // the entry is dropped rather than requested as the literal `&name;`.
+    let mut unresolved = false;
 
     loop {
         match reader.read_event() {
@@ -172,20 +176,21 @@ pub(crate) fn parse_metadata_xml(
             Ok(Event::Eof) => break,
             Ok(Event::Start(e)) => {
                 text.clear();
+                unresolved = false;
                 stack.push(e.name().as_ref().to_string());
             }
             Ok(Event::Text(e)) => text.push_str(&e),
             // CDATA carries the value literally, entity references included.
             Ok(Event::CData(e)) => text.push_str(&e),
             Ok(Event::GeneralRef(e)) => {
-                push_xml_ref(&mut text, &e);
+                unresolved |= !push_xml_ref(&mut text, &e);
             }
             Ok(Event::End(_)) => {
                 let value = text.trim();
                 // Path checks: metadata > versioning > latest | release
                 // Path: metadata > versioning > versions > version
                 let len = stack.len();
-                if !value.is_empty() {
+                if !value.is_empty() && !unresolved {
                     if len >= 3 && stack[len - 3] == "metadata" && stack[len - 2] == "versioning" {
                         match stack[len - 1].as_str() {
                             "latest" => latest = Some(value.to_string()),
@@ -203,6 +208,7 @@ pub(crate) fn parse_metadata_xml(
                 }
                 stack.pop();
                 text.clear();
+                unresolved = false;
             }
             _ => {}
         }
@@ -485,5 +491,25 @@ mod tests {
         let (latest, _release, versions) = parse_metadata_xml(xml).expect("parse ok");
         assert_eq!(latest.as_deref(), Some("1.0&2"));
         assert_eq!(versions, vec!["1.0&2"]);
+    }
+
+    #[test]
+    fn test_parse_metadata_xml_drops_unresolvable_entity() {
+        // Every value here ends up in the pom URL `{base}/{group}/{artifact}/{v}/…`,
+        // so a version we cannot read as written must not become a request.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <versioning>
+    <release>&custom;</release>
+    <versions>
+      <version>&custom;</version>
+      <version>1.0</version>
+    </versions>
+  </versioning>
+</metadata>
+"#;
+        let (_latest, release, versions) = parse_metadata_xml(xml).expect("parse ok");
+        assert_eq!(release, None, "an unresolvable <release> is not a version");
+        assert_eq!(versions, vec!["1.0"], "siblings are still collected");
     }
 }

--- a/depsy-lsp/src/registries/maven_central.rs
+++ b/depsy-lsp/src/registries/maven_central.rs
@@ -25,6 +25,7 @@ use quick_xml::reader::Reader;
 use reqwest::Client;
 
 use crate::config::MavenRegistryConfig;
+use crate::utils::push_xml_ref;
 
 use super::{Registry, VersionInfo};
 
@@ -152,41 +153,52 @@ pub(crate) fn parse_metadata_xml(
     content: &str,
 ) -> Option<(Option<String>, Option<String>, Vec<String>)> {
     let mut reader = Reader::from_str(content);
-    reader.config_mut().trim_text(true);
+    // Keep the raw text: `trim_text(true)` trims each fragment of a value split by
+    // an entity reference on its own. The assembled value is trimmed on `End`.
+    reader.config_mut().trim_text(false);
 
     let mut latest: Option<String> = None;
     let mut release: Option<String> = None;
     let mut versions: Vec<String> = Vec::new();
 
     let mut stack: Vec<String> = Vec::new();
+    // Text of the element being read, assembled across the `Text` / `GeneralRef`
+    // fragments quick-xml emits for a single value.
+    let mut text = String::new();
 
     loop {
         match reader.read_event() {
             Err(_) => return None,
             Ok(Event::Eof) => break,
-            Ok(Event::Start(e)) => stack.push(e.name().as_ref().to_string()),
-            Ok(Event::End(_)) => {
-                stack.pop();
+            Ok(Event::Start(e)) => {
+                text.clear();
+                stack.push(e.name().as_ref().to_string());
             }
-            Ok(Event::Text(e)) => {
-                let text = e.to_string();
+            Ok(Event::Text(e)) => text.push_str(&e),
+            Ok(Event::GeneralRef(e)) => push_xml_ref(&mut text, &e),
+            Ok(Event::End(_)) => {
+                let value = text.trim();
                 // Path checks: metadata > versioning > latest | release
                 // Path: metadata > versioning > versions > version
                 let len = stack.len();
-                if len >= 3 && stack[len - 3] == "metadata" && stack[len - 2] == "versioning" {
-                    match stack[len - 1].as_str() {
-                        "latest" => latest = Some(text),
-                        "release" => release = Some(text),
-                        _ => {}
+                if !value.is_empty() {
+                    if len >= 3 && stack[len - 3] == "metadata" && stack[len - 2] == "versioning" {
+                        match stack[len - 1].as_str() {
+                            "latest" => latest = Some(value.to_string()),
+                            "release" => release = Some(value.to_string()),
+                            _ => {}
+                        }
+                    } else if len >= 4
+                        && stack[len - 4] == "metadata"
+                        && stack[len - 3] == "versioning"
+                        && stack[len - 2] == "versions"
+                        && stack[len - 1] == "version"
+                    {
+                        versions.push(value.to_string());
                     }
-                } else if len >= 4
-                    && stack[len - 4] == "metadata"
-                    && stack[len - 3] == "versioning"
-                    && stack[len - 2] == "versions"
-                    && stack[len - 1] == "version"
-                {
-                    versions.push(text);
                 }
+                stack.pop();
+                text.clear();
             }
             _ => {}
         }
@@ -208,7 +220,10 @@ pub(crate) fn parse_pom_metadata(
     Option<String>,
 ) {
     let mut reader = Reader::from_str(content);
-    reader.config_mut().trim_text(true);
+    // Keep the raw text: `trim_text(true)` trims each fragment of a value split by
+    // an entity reference on its own, which would eat the spaces around `&amp;` in
+    // e.g. `<name>GPL &amp; Classpath Exception</name>`.
+    reader.config_mut().trim_text(false);
 
     let mut description: Option<String> = None;
     let mut homepage: Option<String> = None;
@@ -216,42 +231,52 @@ pub(crate) fn parse_pom_metadata(
     let mut licenses: Vec<String> = Vec::new();
 
     let mut stack: Vec<String> = Vec::new();
+    // Text of the element being read, assembled across the `Text` / `GeneralRef`
+    // fragments quick-xml emits for a single value.
+    let mut text = String::new();
 
     loop {
         match reader.read_event() {
             Err(_) => break,
             Ok(Event::Eof) => break,
-            Ok(Event::Start(e)) => stack.push(e.name().as_ref().to_string()),
-            Ok(Event::End(_)) => {
-                stack.pop();
+            Ok(Event::Start(e)) => {
+                text.clear();
+                stack.push(e.name().as_ref().to_string());
             }
-            Ok(Event::Text(e)) => {
-                let text = e.to_string();
+            Ok(Event::Text(e)) => text.push_str(&e),
+            Ok(Event::GeneralRef(e)) => push_xml_ref(&mut text, &e),
+            Ok(Event::End(_)) => {
+                let value = text.trim();
                 let len = stack.len();
-                // project > description
-                if len == 2 && stack[0] == "project" && stack[1] == "description" {
-                    description = Some(text);
-                    continue;
+                if !value.is_empty() {
+                    // project > description
+                    if len == 2 && stack[0] == "project" && stack[1] == "description" {
+                        description = Some(value.to_string());
+                    }
+                    // project > url
+                    else if len == 2 && stack[0] == "project" && stack[1] == "url" {
+                        homepage = Some(value.to_string());
+                    }
+                    // project > scm > url
+                    else if len == 3
+                        && stack[0] == "project"
+                        && stack[1] == "scm"
+                        && stack[2] == "url"
+                    {
+                        repository = Some(value.to_string());
+                    }
+                    // project > licenses > license > name
+                    else if len == 4
+                        && stack[0] == "project"
+                        && stack[1] == "licenses"
+                        && stack[2] == "license"
+                        && stack[3] == "name"
+                    {
+                        licenses.push(value.to_string());
+                    }
                 }
-                // project > url
-                if len == 2 && stack[0] == "project" && stack[1] == "url" {
-                    homepage = Some(text);
-                    continue;
-                }
-                // project > scm > url
-                if len == 3 && stack[0] == "project" && stack[1] == "scm" && stack[2] == "url" {
-                    repository = Some(text);
-                    continue;
-                }
-                // project > licenses > license > name
-                if len == 4
-                    && stack[0] == "project"
-                    && stack[1] == "licenses"
-                    && stack[2] == "license"
-                    && stack[3] == "name"
-                {
-                    licenses.push(text);
-                }
+                stack.pop();
+                text.clear();
             }
             _ => {}
         }
@@ -391,5 +416,66 @@ mod tests {
         // `-m` alone (no digit) must NOT classify as milestone.
         assert!(!is_prerelease("1.0-metrics"));
         assert!(!is_prerelease("2.4-mixed"));
+    }
+
+    #[test]
+    fn test_parse_pom_metadata_with_entity_references() {
+        let pom = r#"<?xml version="1.0"?>
+<project>
+    <description>Fast &amp; small logging</description>
+    <url>https://example.com/?a=1&amp;b=2</url>
+    <scm>
+        <url>https://github.com/ex/ex?tab=1&amp;view=2</url>
+    </scm>
+    <licenses>
+        <license>
+            <name>GPL &amp; Classpath Exception</name>
+        </license>
+        <license>
+            <name>CDDL &amp; GPL</name>
+        </license>
+    </licenses>
+</project>
+"#;
+        let (description, homepage, repository, license) = parse_pom_metadata(pom);
+        assert_eq!(
+            description.as_deref(),
+            Some("Fast & small logging"),
+            "entity references must be resolved, not truncate the value"
+        );
+        assert_eq!(homepage.as_deref(), Some("https://example.com/?a=1&b=2"));
+        assert_eq!(
+            repository.as_deref(),
+            Some("https://github.com/ex/ex?tab=1&view=2")
+        );
+        assert_eq!(
+            license.as_deref(),
+            Some("GPL & Classpath Exception, CDDL & GPL")
+        );
+    }
+
+    #[test]
+    fn test_parse_pom_metadata_empty_elements_stay_none() {
+        let pom = "<project><description></description><url>   </url></project>";
+        let (description, homepage, _, _) = parse_pom_metadata(pom);
+        assert_eq!(description, None, "an empty element yields no value");
+        assert_eq!(homepage, None, "a whitespace-only element yields no value");
+    }
+
+    #[test]
+    fn test_parse_metadata_xml_with_entity_reference() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <versioning>
+    <latest>1.0&amp;2</latest>
+    <versions>
+      <version>1.0&amp;2</version>
+    </versions>
+  </versioning>
+</metadata>
+"#;
+        let (latest, _release, versions) = parse_metadata_xml(xml).expect("parse ok");
+        assert_eq!(latest.as_deref(), Some("1.0&2"));
+        assert_eq!(versions, vec!["1.0&2"]);
     }
 }

--- a/depsy-lsp/src/registries/maven_central.rs
+++ b/depsy-lsp/src/registries/maven_central.rs
@@ -175,7 +175,11 @@ pub(crate) fn parse_metadata_xml(
                 stack.push(e.name().as_ref().to_string());
             }
             Ok(Event::Text(e)) => text.push_str(&e),
-            Ok(Event::GeneralRef(e)) => push_xml_ref(&mut text, &e),
+            // CDATA carries the value literally, entity references included.
+            Ok(Event::CData(e)) => text.push_str(&e),
+            Ok(Event::GeneralRef(e)) => {
+                push_xml_ref(&mut text, &e);
+            }
             Ok(Event::End(_)) => {
                 let value = text.trim();
                 // Path checks: metadata > versioning > latest | release
@@ -244,7 +248,11 @@ pub(crate) fn parse_pom_metadata(
                 stack.push(e.name().as_ref().to_string());
             }
             Ok(Event::Text(e)) => text.push_str(&e),
-            Ok(Event::GeneralRef(e)) => push_xml_ref(&mut text, &e),
+            // CDATA carries the value literally, entity references included.
+            Ok(Event::CData(e)) => text.push_str(&e),
+            Ok(Event::GeneralRef(e)) => {
+                push_xml_ref(&mut text, &e);
+            }
             Ok(Event::End(_)) => {
                 let value = text.trim();
                 let len = stack.len();

--- a/depsy-lsp/src/utils.rs
+++ b/depsy-lsp/src/utils.rs
@@ -2,6 +2,8 @@
 
 use core::fmt::{self, Write as _};
 
+use quick_xml::events::BytesRef;
+
 /// Returns an <code>[fmt::Display] + [fmt::Debug]</code> implementation
 /// which truncates the given string to a maximum character count.
 ///
@@ -78,6 +80,44 @@ pub fn html_escape(s: &str) -> String {
         }
     }
     out
+}
+
+/// Appends the text an XML reference stands for to `out`.
+///
+/// quick-xml emits every `&…;` inside element content as a standalone
+/// [`Event::GeneralRef`](quick_xml::events::Event::GeneralRef) sandwiched
+/// between two `Event::Text` events, so a parser that assembles element text
+/// has to fold the reference back in itself. Numeric character references
+/// (`&#45;`, `&#x2D;`) and the five predefined XML entities (`amp`, `lt`, `gt`,
+/// `apos`, `quot`) are resolved; anything else — a DTD-declared entity, a typo —
+/// is written back verbatim as `&name;` so the value is preserved rather than
+/// silently dropped.
+///
+/// # Examples
+///
+/// ```
+/// use depsy_lsp::utils::push_xml_ref;
+/// use quick_xml::events::BytesRef;
+///
+/// let mut out = String::from("a");
+/// push_xml_ref(&mut out, &BytesRef::new("amp"));
+/// push_xml_ref(&mut out, &BytesRef::new("#98"));
+/// push_xml_ref(&mut out, &BytesRef::new("custom"));
+/// assert_eq!(out, "a&b&custom;");
+/// ```
+pub fn push_xml_ref(out: &mut String, entity: &BytesRef<'_>) {
+    if let Ok(Some(c)) = entity.resolve_char_ref() {
+        out.push(c);
+        return;
+    }
+    let name: &str = entity;
+    match quick_xml::escape::resolve_xml_entity(name) {
+        Some(text) => out.push_str(text),
+        // Unknown entity: keep the source form. Writing to a String never fails.
+        None => {
+            let _ = write!(out, "&{name};");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/depsy-lsp/src/utils.rs
+++ b/depsy-lsp/src/utils.rs
@@ -82,16 +82,23 @@ pub fn html_escape(s: &str) -> String {
     out
 }
 
-/// Appends the text an XML reference stands for to `out`.
+/// Appends the text an XML reference stands for, reporting whether it resolved.
 ///
 /// quick-xml emits every `&…;` inside element content as a standalone
-/// [`Event::GeneralRef`](quick_xml::events::Event::GeneralRef) sandwiched
-/// between two `Event::Text` events, so a parser that assembles element text
-/// has to fold the reference back in itself. Numeric character references
-/// (`&#45;`, `&#x2D;`) and the five predefined XML entities (`amp`, `lt`, `gt`,
-/// `apos`, `quot`) are resolved; anything else — a DTD-declared entity, a typo —
-/// is written back verbatim as `&name;` so the value is preserved rather than
-/// silently dropped.
+/// [`Event::GeneralRef`](quick_xml::events::Event::GeneralRef) sitting between
+/// the surrounding `Event::Text` runs, so a parser that assembles element text
+/// has to fold the reference back in itself. There is no `Text` event on a side
+/// where the reference starts or ends the content: `<version>&amp;</version>`
+/// yields one `GeneralRef` and nothing else.
+///
+/// Numeric character references (`&#45;`, `&#x2D;`) and the five predefined XML
+/// entities (`amp`, `lt`, `gt`, `apos`, `quot`) resolve and the call returns
+/// `true`. Anything else — a DTD-declared entity, a typo, a code point that is
+/// not a character — is written back verbatim as `&name;` so the value is
+/// preserved rather than silently dropped, and the call returns `false`.
+/// Callers feeding the text into something stricter than free prose (a registry
+/// lookup, a version comparison) should read `false` as "value not understood"
+/// rather than accept the literal `&name;`.
 ///
 /// # Examples
 ///
@@ -100,22 +107,26 @@ pub fn html_escape(s: &str) -> String {
 /// use quick_xml::events::BytesRef;
 ///
 /// let mut out = String::from("a");
-/// push_xml_ref(&mut out, &BytesRef::new("amp"));
-/// push_xml_ref(&mut out, &BytesRef::new("#98"));
-/// push_xml_ref(&mut out, &BytesRef::new("custom"));
+/// assert!(push_xml_ref(&mut out, &BytesRef::new("amp")));
+/// assert!(push_xml_ref(&mut out, &BytesRef::new("#98")));
+/// assert!(!push_xml_ref(&mut out, &BytesRef::new("custom")));
 /// assert_eq!(out, "a&b&custom;");
 /// ```
-pub fn push_xml_ref(out: &mut String, entity: &BytesRef<'_>) {
+pub fn push_xml_ref(out: &mut String, entity: &BytesRef<'_>) -> bool {
     if let Ok(Some(c)) = entity.resolve_char_ref() {
         out.push(c);
-        return;
+        return true;
     }
     let name: &str = entity;
     match quick_xml::escape::resolve_xml_entity(name) {
-        Some(text) => out.push_str(text),
+        Some(text) => {
+            out.push_str(text);
+            true
+        }
         // Unknown entity: keep the source form. Writing to a String never fails.
         None => {
             let _ = write!(out, "&{name};");
+            false
         }
     }
 }
@@ -215,5 +226,43 @@ mod tests {
     fn test_html_escape_idempotent_on_safe_text() {
         let safe = "plain text with digits 42 and unicode é";
         assert_eq!(html_escape(safe), safe);
+    }
+
+    #[test]
+    fn test_push_xml_ref_resolves_numeric_refs() {
+        let mut out = String::new();
+        assert!(push_xml_ref(&mut out, &BytesRef::new("#45")));
+        assert!(push_xml_ref(&mut out, &BytesRef::new("#x2D")));
+        assert_eq!(out, "--", "decimal and hex forms both yield U+002D");
+    }
+
+    #[test]
+    fn test_push_xml_ref_resolves_predefined_entities() {
+        let mut out = String::new();
+        for name in ["amp", "lt", "gt", "quot", "apos"] {
+            assert!(
+                push_xml_ref(&mut out, &BytesRef::new(name)),
+                "predefined entity {name} should resolve"
+            );
+        }
+        assert_eq!(out, "&<>\"'");
+    }
+
+    #[test]
+    fn test_push_xml_ref_keeps_unresolvable_refs_verbatim() {
+        // A lone surrogate is not a character, so the numeric form cannot resolve.
+        let mut out = String::new();
+        assert!(!push_xml_ref(&mut out, &BytesRef::new("#xD800")));
+        assert_eq!(out, "&#xD800;");
+
+        // Neither predefined nor numeric: an HTML entity a pom may still carry.
+        out.clear();
+        assert!(!push_xml_ref(&mut out, &BytesRef::new("nbsp")));
+        assert_eq!(out, "&nbsp;");
+
+        // A malformed numeric reference falls through the same way.
+        out.clear();
+        assert!(!push_xml_ref(&mut out, &BytesRef::new("#zz")));
+        assert_eq!(out, "&#zz;");
     }
 }

--- a/depsy-lsp/tests/fuzz_regression.rs
+++ b/depsy-lsp/tests/fuzz_regression.rs
@@ -1,7 +1,8 @@
 //! Regression tests for fuzz crashes
 
 use depsy_lsp::parsers::{
-    Parser, cargo::CargoParser, npm::NpmParser, php::PhpParser, python::PythonParser,
+    Parser, cargo::CargoParser, maven::MavenParser, npm::NpmParser, php::PhpParser,
+    python::PythonParser,
 };
 use std::panic::AssertUnwindSafe;
 
@@ -357,6 +358,82 @@ extra-dependencies = [
         match result {
             Ok(deps) => validate_deps(&deps, content, "Python/hatch-standalone"),
             Err(_) => panic!("Python parser panicked on standalone hatch.toml input:\n{content:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_maven_fuzz_spans() {
+    // The pom parser reports spans assembled from several XML events, so a value
+    // interrupted by an entity reference, a comment or a line break must still
+    // land inside one line of the source.
+    let parser = MavenParser::new();
+
+    let valid = r#"<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <groupId>com.example</groupId>
+    <artifactId>app</artifactId>
+    <version>1.0.0</version>
+    <properties>
+        <slf4j.version>1.7.30</slf4j.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+"#;
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| parser.parse(valid)));
+    let deps = result.expect("should not panic on a valid pom.xml");
+    assert_eq!(deps.len(), 2, "expected both declared dependencies");
+    validate_deps(&deps, valid, "Maven");
+
+    // --- Edge cases: must not panic and must satisfy position invariants ---
+    let edge_cases: &[&str] = &[
+        // entity reference splitting the version
+        "<project><dependencies><dependency><groupId>g</groupId><artifactId>a</artifactId><version>1.0&amp;2</version></dependency></dependencies></project>",
+        // value straddling a line break
+        "<project><dependencies><dependency><groupId>g</groupId><artifactId>a</artifactId><version>1.0&amp;\n2</version></dependency></dependencies></project>",
+        // comment inside the version
+        "<project><dependencies><dependency><groupId>g</groupId><artifactId>a</artifactId><version>1.0<!-- c -->2.0</version></dependency></dependencies></project>",
+        // CDATA inside the version
+        "<project><dependencies><dependency><groupId>g</groupId><artifactId>a</artifactId><version>1.<![CDATA[0]]>5</version></dependency></dependencies></project>",
+        // unexpandable entity as the whole version
+        "<project><dependencies><dependency><groupId>g</groupId><artifactId>a</artifactId><version>&ver;</version></dependency></dependencies></project>",
+        // exclusions repeating the coordinate element names
+        "<project><dependencies><dependency><groupId>g</groupId><artifactId>a</artifactId><version>1.0</version><exclusions><exclusion><groupId>x</groupId><artifactId>y</artifactId></exclusion></exclusions></dependency></dependencies></project>",
+        // multi-line artifactId
+        "<project><dependencies><dependency><groupId>g</groupId><artifactId>a&amp;\nb</artifactId><version>1.0</version></dependency></dependencies></project>",
+        // whitespace-only version
+        "<project><dependencies><dependency><groupId>g</groupId><artifactId>a</artifactId><version>   </version></dependency></dependencies></project>",
+        // self-closing coordinate elements
+        "<project><dependencies><dependency><groupId/><artifactId/><version/></dependency></dependencies></project>",
+        // stray end tag
+        "<project></dependency></project>",
+        // truncated document
+        "<project><dependencies><dependency><groupId>g",
+        // empty input
+        "",
+        // control characters in a coordinate
+        "<project><dependencies><dependency><groupId>\u{1}g</groupId><artifactId>a</artifactId><version>1.0</version></dependency></dependencies></project>",
+        // non-ASCII coordinate
+        "<project><dependencies><dependency><groupId>café</groupId><artifactId>naïve</artifactId><version>1.0</version></dependency></dependencies></project>",
+    ];
+
+    for content in edge_cases {
+        let result = std::panic::catch_unwind(AssertUnwindSafe(|| parser.parse(content)));
+        match result {
+            Ok(deps) => validate_deps(&deps, content, "Maven"),
+            Err(_) => panic!("Maven parser panicked on input:\n{content:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

`Event::GeneralRef` was not handled in the Maven XML paths, so any value containing an XML entity reference was truncated to a single fragment. quick-xml reports every `&…;` inside element content as a standalone `Event::GeneralRef` between two `Event::Text` events, and the four Maven loops matched `Event::Text` only, each fragment *replacing* the accumulator instead of appending to it.

`extract_dependencies` kept the last fragment, `extract_properties` the first (its `!out.contains_key` guard). Maven coordinates are restricted to `[A-Za-z0-9_.-]`, so the reachable damage was in the pom metadata shown on hover — descriptions, URLs with query strings, "X & Y" license names — and in property values.

A second cause, not in the issue: `trim_text(true)` trims each fragment on its own, so simply concatenating would have turned `GPL &amp; Classpath` into `GPL&Classpath`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issue

Closes #394

## Changes Made

- `utils::push_xml_ref` resolves a `BytesRef`: numeric character references via `resolve_char_ref`, the five predefined XML entities via `escape::resolve_xml_entity`. Anything else — a DTD-declared entity, a typo — is written back verbatim as `&name;` instead of being dropped.
- Element text is accumulated across `Text` and `GeneralRef` fragments and flushed on `End`, in `extract_properties`, `extract_dependencies` (`parsers/maven.rs`), `parse_metadata_xml` and `parse_pom_metadata` (`registries/maven_central.rs`).
- The three loops that ran with `trim_text(true)` move to `trim_text(false)` plus a manual trim of the assembled value. Flushing is skipped when the trimmed value is empty, which keeps the existing behaviour of empty and whitespace-only elements yielding no value.
- Spans were wrong the same way. `trimmed_span` derived its start from `buffer_position() - raw_len`, which only holds when a value arrives as a single event; it now takes the reader position captured *before* `read_event()` for the first fragment through the position after the last. `<version>3.1&amp;4</version>` reports the whole run instead of the trailing `4`.
- CHANGELOG entry under `[Unreleased] > Fixed`.

## Testing

- [x] `cargo test` passes — 923 passed, 0 failed
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] Tested manually in Zed

9 regression tests. The issue's reproduction is `test_parse_dependency_with_entity_references` verbatim. The rest cover spans, numeric character references (`&#45;`), an unresolvable entity kept as written, spaces around `&amp;`, property substitution, `<description>`/`<url>`/`<scm><url>`/multiple licenses, `maven-metadata.xml`, and empty elements still yielding `None`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality
- [x] All new and existing tests pass

## Out of scope

- `csharp.rs` is untouched. It already handles `Event::GeneralRef` and marks the version fragmented via `mark_fragmented_version`, dropping the dependency rather than reporting a truncated version — deliberate and correct.
- CDATA is still ignored in the Maven paths: `<description><![CDATA[Fast & small]]></description>` yields `None`. Same class of lost value, but a different gap (no `Event::CData` arm at all) and not what #394 reports.

## Follow-ups worth considering

- The four text-assembly loops remain copy-pasted; only `push_xml_ref` is shared. A common accumulator would stop the next copy from repeating this.
- There are 8 fuzz targets and none for Maven/XML. Fuzzing pom.xml would have caught this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Maven XML parsing so element values containing entity references or CDATA are no longer truncated or lost (#394), and skips dependencies whose coordinates can't be located exactly instead of misreporting them.

**Bug Fixes**

- Element text is assembled across `Text`, `CData`, and `GeneralRef` events; `push_xml_ref` resolves numeric and predefined XML entities and preserves unresolvable ones verbatim.
- Values are trimmed once after assembly, keeping spaces around `&amp;`, and spans now cover the whole raw value.
- Only direct children of `<dependency>` set `groupId`, `artifactId`, and `version`, so an `<exclusion>` can't overwrite them.
- A coordinate that is unexpandable, split across lines, or interrupted by a comment is skipped, because it has no valid single-line span for the update quick-fix.
- A property or `maven-metadata.xml` version holding an unresolvable entity is dropped, so `${key}` stays unsubstituted and the literal `&name;` never reaches the registry.

<sup>Written for commit 8a6dd546a48f4092d0fc86fa4926450dd87ba960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/zed-depsy/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Maven XML parsing for CDATA, entity references, whitespace, and empty values.
  * Preserved unknown entity references in free text while safely omitting unresolved properties and metadata versions.
  * Corrected dependency and exclusion coordinate extraction.
  * Skipped dependencies with unresolved, fragmented, multiline, or unreliable coordinates and versions.
  * Improved source-range accuracy for interrupted XML values.

* **Tests**
  * Added coverage for malformed XML and source-span safety across Maven edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->