### PR TITLE
fix(lsp): parse Cargo target-specific dependency sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cargo target-specific sections (`[target.'cfg(unix)'.dependencies]`,
+  `[target.<triple>.dev-dependencies]`, and their `build-dependencies`
+  variants) are now parsed, so their crates get versions, diagnostics, and
+  update actions like any other dependency.
+  ([#396](https://github.com/mpiton/zed-depsy/issues/396))
 - Maven XML values containing an entity reference are no longer truncated.
   quick-xml reports `&amp;` as its own event between two text events, and the
   Maven parsers kept a single fragment instead of joining them, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   variants) are now parsed, so their crates get versions, diagnostics, and
   update actions like any other dependency.
   ([#396](https://github.com/mpiton/zed-depsy/issues/396))
+- The vulnerability report no longer counts a crate twice when it is declared in
+  several sections at once — a common cross-platform pattern is to list the same
+  crate under `[dependencies]` and one or more `[target.<cfg>.dependencies]`
+  tables, which used to inflate the critical/high totals.
 - Maven XML values containing an entity reference are no longer truncated.
   quick-xml reports `&amp;` as its own event between two text events, and the
   Maven parsers kept a single fragment instead of joining them, so

--- a/depsy-lsp/src/backend.rs
+++ b/depsy-lsp/src/backend.rs
@@ -43,7 +43,7 @@ use std::{
 };
 
 use dashmap::DashMap;
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use reqwest::Client as HttpClient;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
@@ -80,7 +80,7 @@ use crate::registries::packagist::PackagistRegistry;
 use crate::registries::pub_dev::PubDevRegistry;
 use crate::registries::pypi::PyPiRegistry;
 use crate::registries::rubygems::RubyGemsRegistry;
-use crate::registries::{Registry, VersionInfo, VulnerabilitySeverity};
+use crate::registries::{Registry, VersionInfo, Vulnerability, VulnerabilitySeverity};
 use crate::reports::{VulnerabilityReportEntry, VulnerabilitySummary};
 use crate::vulnerabilities::cache::VulnerabilityCache;
 use crate::vulnerabilities::osv::OsvClient;
@@ -1236,32 +1236,15 @@ impl DepsyBackend {
         };
 
         // Collect vulnerabilities from the version cache
-        let mut vulnerabilities: Vec<VulnerabilityReportEntry> = Vec::new();
-        let mut summary = VulnerabilitySummary::default();
-
+        let mut hits: Vec<(&crate::parsers::Dependency, Vec<Vulnerability>)> = Vec::new();
         for dep in &dependencies {
             let cache_key = dep_cache_key(dep, file_type);
             if let Some(info) = self.version_cache.get(&cache_key).await {
-                for vuln in &info.vulnerabilities {
-                    summary.total += 1;
-                    match vuln.severity {
-                        VulnerabilitySeverity::Critical => summary.critical += 1,
-                        VulnerabilitySeverity::High => summary.high += 1,
-                        VulnerabilitySeverity::Medium => summary.medium += 1,
-                        VulnerabilitySeverity::Low => summary.low += 1,
-                    }
-
-                    vulnerabilities.push(VulnerabilityReportEntry {
-                        package: dep.name.clone(),
-                        version: dep.version.clone(),
-                        id: vuln.id.clone(),
-                        severity: format!("{:?}", vuln.severity).to_lowercase(),
-                        description: vuln.description.clone(),
-                        url: vuln.url.clone(),
-                    });
-                }
+                hits.push((dep, info.vulnerabilities.clone()));
             }
         }
+        let (summary, vulnerabilities) =
+            build_vulnerability_report(hits.iter().map(|(dep, vulns)| (*dep, vulns.as_slice())));
 
         // Generate report based on format
         match format {
@@ -1287,6 +1270,49 @@ impl DepsyBackend {
 /// Format the hover content for a dependency with version info.
 ///
 /// Extracted from the hover handler to enable unit testing.
+/// Folds cached advisories into a report plus its severity summary.
+///
+/// A crate declared in several sections — the manifest root plus one or more
+/// `[target.<cfg>]` tables — produces one [`Dependency`] per declaration, each
+/// carrying its own span. They all resolve to the same cache entry, so the same
+/// advisory is reachable several times; `(package, version, id)` is counted and
+/// listed once so the summary is not inflated.
+///
+/// [`Dependency`]: crate::parsers::Dependency
+fn build_vulnerability_report<'a>(
+    hits: impl IntoIterator<Item = (&'a crate::parsers::Dependency, &'a [Vulnerability])>,
+) -> (VulnerabilitySummary, Vec<VulnerabilityReportEntry>) {
+    let mut summary = VulnerabilitySummary::default();
+    let mut entries: Vec<VulnerabilityReportEntry> = Vec::new();
+    let mut seen: HashSet<(&str, &str, &str)> = HashSet::new();
+
+    for (dep, vulns) in hits {
+        for vuln in vulns {
+            if !seen.insert((&dep.name, &dep.version, &vuln.id)) {
+                continue;
+            }
+            summary.total += 1;
+            match vuln.severity {
+                VulnerabilitySeverity::Critical => summary.critical += 1,
+                VulnerabilitySeverity::High => summary.high += 1,
+                VulnerabilitySeverity::Medium => summary.medium += 1,
+                VulnerabilitySeverity::Low => summary.low += 1,
+            }
+
+            entries.push(VulnerabilityReportEntry {
+                package: dep.name.clone(),
+                version: dep.version.clone(),
+                id: vuln.id.clone(),
+                severity: format!("{:?}", vuln.severity).to_lowercase(),
+                description: vuln.description.clone(),
+                url: vuln.url.clone(),
+            });
+        }
+    }
+
+    (summary, entries)
+}
+
 fn format_hover_content(
     dep: &crate::parsers::Dependency,
     file_type: FileType,
@@ -2006,6 +2032,60 @@ mod tests {
             resolved_version: resolved.map(str::to_string),
             has_additional_version_constraints: false,
         }
+    }
+
+    #[test]
+    fn vulnerability_report_counts_a_crate_declared_in_several_sections_once() {
+        // Same crate in [dependencies] and two [target.<cfg>.dependencies] tables:
+        // three Dependency values, three spans, one cache entry.
+        let root = make_dep("libc", "0.2", None);
+        let linux = make_dep("libc", "0.2", None);
+        let macos = make_dep("libc", "0.2", None);
+        let vulns = [Vulnerability {
+            id: "RUSTSEC-0000-0000".to_string(),
+            severity: VulnerabilitySeverity::Critical,
+            description: "boom".to_string(),
+            url: None,
+        }];
+
+        let (summary, entries) = build_vulnerability_report([
+            (&root, vulns.as_slice()),
+            (&linux, vulns.as_slice()),
+            (&macos, vulns.as_slice()),
+        ]);
+
+        assert_eq!(summary.total, 1, "{entries:#?}");
+        assert_eq!(summary.critical, 1);
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn vulnerability_report_keeps_distinct_advisories_and_versions() {
+        let serde = make_dep("serde", "1.0", None);
+        let libc = make_dep("libc", "0.2", None);
+        let critical = Vulnerability {
+            id: "RUSTSEC-0000-0001".to_string(),
+            severity: VulnerabilitySeverity::Critical,
+            description: "one".to_string(),
+            url: None,
+        };
+        let low = Vulnerability {
+            id: "RUSTSEC-0000-0002".to_string(),
+            severity: VulnerabilitySeverity::Low,
+            description: "two".to_string(),
+            url: None,
+        };
+
+        let (summary, entries) = build_vulnerability_report([
+            (&serde, std::slice::from_ref(&critical)),
+            (&libc, std::slice::from_ref(&critical)),
+            (&libc, std::slice::from_ref(&low)),
+        ]);
+
+        assert_eq!(summary.total, 3, "{entries:#?}");
+        assert_eq!(summary.critical, 2);
+        assert_eq!(summary.low, 1);
+        assert_eq!(entries.len(), 3);
     }
 
     #[test]

--- a/depsy-lsp/src/parsers/cargo.rs
+++ b/depsy-lsp/src/parsers/cargo.rs
@@ -8,6 +8,7 @@
 //! - Package alias: `serde1 = { package = "serde", version = "1.0" }`
 //! - Workspace dependencies: `[workspace.dependencies]`
 //! - All three scopes: `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`
+//! - Target-specific scopes: `[target.'cfg(unix)'.dependencies]` and friends
 //!
 //! Parsing is performed with `taplo` so that byte-accurate [`Span`] values are
 //! available for every token; this allows LSP quick-fix `TextEdit`s to replace
@@ -62,8 +63,9 @@ pub fn cargo_root_package_name(manifest_content: &str) -> Option<String> {
 ///
 /// Delegates to the `taplo` TOML parser for robust span tracking.
 /// All three standard dependency scopes (`dependencies`, `dev-dependencies`,
-/// `build-dependencies`) as well as `workspace.dependencies` are parsed in a
-/// single pass.
+/// `build-dependencies`), their target-specific counterparts
+/// (`[target.<cfg>.dependencies]`), and `workspace.dependencies` are parsed in
+/// a single pass.
 ///
 /// # Examples
 ///
@@ -129,6 +131,25 @@ impl Parser for CargoParser {
                 .iter()
                 .filter_map(|(name, value)| parse_dependency(name, value, &line_ranges, is_dev));
             dependencies.extend(deps);
+        }
+
+        // Parse target-specific sections (e.g. [target.'cfg(unix)'.dependencies])
+        let target_node = dom.get("target");
+        if let Some(target_table) = target_node.as_table() {
+            let targets = target_table.entries().read();
+            for (_, cfg_node) in targets.iter() {
+                for (section_name, is_dev) in sections {
+                    let section_node = cfg_node.get(section_name);
+                    let Some(section) = section_node.as_table() else {
+                        continue;
+                    };
+                    let entries = section.entries().read();
+                    let deps = entries.iter().filter_map(|(name, value)| {
+                        parse_dependency(name, value, &line_ranges, is_dev)
+                    });
+                    dependencies.extend(deps);
+                }
+            }
         }
 
         // Parse workspace.dependencies section
@@ -524,5 +545,41 @@ members = ["crate-a"]
     #[test]
     fn test_cargo_root_package_name_returns_none_for_invalid_toml() {
         assert_eq!(cargo_root_package_name("not [valid toml ="), None);
+    }
+
+    #[test]
+    fn test_target_specific_dependencies() {
+        let parser = CargoParser::new();
+        let content = r#"
+[dependencies]
+serde = "1.0"
+
+[target.'cfg(unix)'.dependencies]
+nix = "0.29.0"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59.0", features = ["Win32_Foundation"] }
+
+[target.x86_64-unknown-linux-gnu.dev-dependencies]
+criterion = "0.5"
+
+[target.'cfg(target_os = "macos")'.build-dependencies]
+cc = "1.0"
+"#;
+        let deps = parser.parse(content);
+        assert_eq!(deps.len(), 5, "{deps:#?}");
+
+        let nix = deps.iter().find(|d| d.name == "nix").unwrap();
+        assert_eq!(nix.version, "0.29.0");
+        assert!(!nix.dev);
+        assert_eq!(nix.name_span.line, 5);
+
+        let win = deps.iter().find(|d| d.name == "windows-sys").unwrap();
+        assert_eq!(win.version, "0.59.0");
+
+        let criterion = deps.iter().find(|d| d.name == "criterion").unwrap();
+        assert!(criterion.dev);
+
+        assert!(deps.iter().any(|d| d.name == "cc"));
     }
 }

--- a/depsy-lsp/src/parsers/cargo.rs
+++ b/depsy-lsp/src/parsers/cargo.rs
@@ -8,7 +8,8 @@
 //! - Package alias: `serde1 = { package = "serde", version = "1.0" }`
 //! - Workspace dependencies: `[workspace.dependencies]`
 //! - All three scopes: `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`
-//! - Target-specific scopes: `[target.'cfg(unix)'.dependencies]` and friends
+//! - Target-specific scopes: `[target.'cfg(unix)'.dependencies]`, plus the
+//!   `dev-dependencies` and `build-dependencies` variants under any `[target.<cfg>]`
 //!
 //! Parsing is performed with `taplo` so that byte-accurate [`Span`] values are
 //! available for every token; this allows LSP quick-fix `TextEdit`s to replace
@@ -113,42 +114,15 @@ impl Parser for CargoParser {
 
         let mut dependencies = Vec::new();
 
-        // Define dependency sections to parse: (section_name, is_dev)
-        let sections = [
-            ("dependencies", false),
-            ("dev-dependencies", true),
-            ("build-dependencies", false),
-        ];
+        // Root sections: [dependencies], [dev-dependencies], [build-dependencies]
+        collect_section_deps(&dom, &line_ranges, &mut dependencies);
 
-        for (section_name, is_dev) in sections {
-            // Parse regular section dependencies (e.g., [dependencies])
-            let section_node = dom.get(section_name);
-            let Some(section) = section_node.as_table() else {
-                continue;
-            };
-            let entries = section.entries().read();
-            let deps = entries
-                .iter()
-                .filter_map(|(name, value)| parse_dependency(name, value, &line_ranges, is_dev));
-            dependencies.extend(deps);
-        }
-
-        // Parse target-specific sections (e.g. [target.'cfg(unix)'.dependencies])
+        // Target-specific sections (e.g. [target.'cfg(unix)'.dependencies])
         let target_node = dom.get("target");
         if let Some(target_table) = target_node.as_table() {
             let targets = target_table.entries().read();
             for (_, cfg_node) in targets.iter() {
-                for (section_name, is_dev) in sections {
-                    let section_node = cfg_node.get(section_name);
-                    let Some(section) = section_node.as_table() else {
-                        continue;
-                    };
-                    let entries = section.entries().read();
-                    let deps = entries.iter().filter_map(|(name, value)| {
-                        parse_dependency(name, value, &line_ranges, is_dev)
-                    });
-                    dependencies.extend(deps);
-                }
+                collect_section_deps(cfg_node, &line_ranges, &mut dependencies);
             }
         }
 
@@ -165,6 +139,34 @@ impl Parser for CargoParser {
         }
 
         dependencies
+    }
+}
+
+/// Dependency scopes Cargo accepts under a manifest root or a `[target.<cfg>]`
+/// table, paired with whether the scope is dev-only.
+const DEPENDENCY_SECTIONS: [(&str, bool); 3] = [
+    ("dependencies", false),
+    ("dev-dependencies", true),
+    ("build-dependencies", false),
+];
+
+/// Parses every [`DEPENDENCY_SECTIONS`] table found directly under `container`
+/// and appends the dependencies to `out`.
+///
+/// `container` is the manifest root for `[dependencies]` and friends, or a
+/// single `[target.<cfg>]` table for the target-specific variants.
+fn collect_section_deps(container: &Node, line_spans: &[TextRange], out: &mut Vec<Dependency>) {
+    for (section_name, is_dev) in DEPENDENCY_SECTIONS {
+        let section_node = container.get(section_name);
+        let Some(section) = section_node.as_table() else {
+            continue;
+        };
+        let entries = section.entries().read();
+        out.extend(
+            entries
+                .iter()
+                .filter_map(|(name, value)| parse_dependency(name, value, line_spans, is_dev)),
+        );
     }
 }
 
@@ -547,6 +549,13 @@ members = ["crate-a"]
         assert_eq!(cargo_root_package_name("not [valid toml ="), None);
     }
 
+    /// Slices the text a [`Span`] points at, so a test can pin the exact range a
+    /// version-update `TextEdit` would rewrite.
+    fn span_text<'a>(content: &'a str, span: &Span) -> &'a str {
+        let line = content.lines().nth(span.line as usize).unwrap();
+        &line[span.line_start as usize..span.line_end as usize]
+    }
+
     #[test]
     fn test_target_specific_dependencies() {
         let parser = CargoParser::new();
@@ -565,9 +574,12 @@ criterion = "0.5"
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
 cc = "1.0"
+
+[target.'cfg(unix)'.dependencies.reqwest]
+version = "0.12"
 "#;
         let deps = parser.parse(content);
-        assert_eq!(deps.len(), 5, "{deps:#?}");
+        assert_eq!(deps.len(), 6, "{deps:#?}");
 
         let nix = deps.iter().find(|d| d.name == "nix").unwrap();
         assert_eq!(nix.version, "0.29.0");
@@ -580,6 +592,18 @@ cc = "1.0"
         let criterion = deps.iter().find(|d| d.name == "criterion").unwrap();
         assert!(criterion.dev);
 
-        assert!(deps.iter().any(|d| d.name == "cc"));
+        // The update TextEdit is built from version_span, so pin it on a target dep.
+        let cc = deps.iter().find(|d| d.name == "cc").unwrap();
+        assert_eq!(cc.version, "1.0");
+        assert!(!cc.dev);
+        assert_eq!(cc.version_span.line, 14);
+        assert_eq!(span_text(content, &cc.version_span), "1.0");
+
+        // Sub-table form: the name lives on the header line, the version below it.
+        let reqwest = deps.iter().find(|d| d.name == "reqwest").unwrap();
+        assert_eq!(reqwest.version, "0.12");
+        assert_eq!(reqwest.name_span.line, 16);
+        assert_eq!(reqwest.version_span.line, 17);
+        assert_eq!(span_text(content, &reqwest.version_span), "0.12");
     }
 }

--- a/depsy-lsp/tests/version_update_actions_test.rs
+++ b/depsy-lsp/tests/version_update_actions_test.rs
@@ -97,6 +97,15 @@ async fn parsed_manifests_keep_safe_constraint_shapes_when_updated() {
             expected: "[dependencies]\npackage = \"^5.1.0\"\n",
         },
         UpdateCase {
+            parser: Box::new(CargoParser::new()),
+            file_type: FileType::Cargo,
+            uri: "file:///test/Cargo.toml",
+            package: "package",
+            manifest: "[target.'cfg(unix)'.dependencies]\npackage = \"^4.0.2\"\n",
+            latest: "5.1.0",
+            expected: "[target.'cfg(unix)'.dependencies]\npackage = \"^5.1.0\"\n",
+        },
+        UpdateCase {
             parser: Box::new(NpmParser::new()),
             file_type: FileType::Npm,
             uri: "file:///test/package.json",

--- a/docs/languages/rust.md
+++ b/docs/languages/rust.md
@@ -113,6 +113,24 @@ criterion = "0.5"
 cc = "1.0"
 ```
 
+### Target-Specific Dependencies
+
+```toml
+[target.'cfg(unix)'.dependencies]
+nix = "0.29"
+```
+
+The `dev-dependencies` and `build-dependencies` variants work the same way, and
+the target can be an explicit triple instead of a `cfg` expression:
+
+```toml
+[target.'cfg(windows)'.dev-dependencies]
+windows-sys = "0.59"
+
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+cc = "1.0"
+```
+
 ## Version Specification
 
 Cargo uses semantic versioning with these operators:


### PR DESCRIPTION
## Summary

• `CargoParser` now walks `[target.<cfg>.dependencies]`, `[target.<cfg>.dev-dependencies]` and `[target.<cfg>.build-dependencies]`, so crates declared there get inlay hints, diagnostics and update actions like any other dependency
• Regression test covers `cfg(unix)`, `cfg(windows)` inline tables, an explicit target triple, and `cfg(target_os = "macos")` build-dependencies (spans verified, dev flag preserved)
• CHANGELOG entry under Unreleased

Root cause: `parse()` only looked up the three root scope tables plus `workspace.dependencies`; the `target` subtables were never visited, so those dependencies never reached the providers. Providers themselves are section-agnostic (they consume `Vec<Dependency>` + spans), so the single parser fix covers hints, diagnostics, code actions and completion.

Closes #396

## Type

fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cargo parser so dependencies declared in target-specific sections like `[target.'cfg(unix)'.dependencies]` are now parsed. Previously these crates got no inlay hints, diagnostics, or update actions. The fix walks `target.<cfg>` subtables for all three dependency scopes and preserves the dev flag for dev-dependencies. The vulnerability report now counts each advisory once per (package, version, id) instead of once per declaration, since the same crate can appear in several sections. Closes #396.

<sup>Written for commit 8ea75e1d9969009c0e7eab0abab61d7b6b80681a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/zed-depsy/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vulnerability reports no longer count the same package, version, and advisory more than once.
  * Distinct advisories and package versions continue to be reported separately.

* **New Features**
  * Added support for parsing Cargo dependencies defined for specific targets, including regular, development, and build dependencies.
  * Cargo manifest updates now work with target-specific dependency declarations.

* **Documentation**
  * Documented support for target conditions, `cfg` expressions, and explicit target triples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->