### PR TITLE
chore(release): prepare v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-08-30
+
 ### Changed
 
 - Rust dependencies refreshed: `tokio` 1.53.1, `clap` 4.6.6, `serde` 1.0.229,
@@ -890,7 +892,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In-memory caching for version data
 - Parallel registry requests (5 concurrent)
 
-[Unreleased]: https://github.com/mpiton/zed-depsy/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/mpiton/zed-depsy/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/mpiton/zed-depsy/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/mpiton/zed-depsy/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/mpiton/zed-depsy/compare/v1.10.0...v2.0.0
 [1.10.0]: https://github.com/mpiton/zed-dependi/compare/v1.9.1...v1.10.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Dependency management extension for the [Zed](https://zed.dev) editor.
 
-**Version:** 2.0.1
+**Version:** 2.0.2
 
 ![Demo](docs/demo.gif)
 

--- a/depsy-lsp/Cargo.lock
+++ b/depsy-lsp/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "depsy-lsp"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/depsy-lsp/Cargo.toml
+++ b/depsy-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "depsy-lsp"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 rust-version = "1.94"
 license = "MIT"

--- a/depsy-lsp/fuzz/Cargo.lock
+++ b/depsy-lsp/fuzz/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "depsy-lsp"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/depsy-zed/Cargo.lock
+++ b/depsy-zed/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "depsy-zed"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "sha2",
  "zed_extension_api",

--- a/depsy-zed/Cargo.toml
+++ b/depsy-zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "depsy-zed"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 rust-version = "1.90"
 license = "MIT"

--- a/depsy-zed/extension.toml
+++ b/depsy-zed/extension.toml
@@ -1,7 +1,7 @@
 id = "depsy-lsp"
 name = "Depsy"
 description = "Dependency management for Zed - version hints, updates, and vulnerability detection"
-version = "2.0.1"
+version = "2.0.2"
 schema_version = 1
 authors = ["Mathieu Piton"]
 repository = "https://github.com/mpiton/zed-depsy"


### PR DESCRIPTION
Cuts the `[Unreleased]` section into `2.0.2` and bumps the version in `depsy-lsp/Cargo.toml`, `depsy-zed/Cargo.toml`, `depsy-zed/extension.toml`, the three lockfiles and the README.

What ships in 2.0.2:

- Cargo target-specific dependency sections (`[target.'cfg(unix)'.dependencies]` and friends) are parsed, and a crate declared in several sections is no longer counted twice in the vulnerability report (#396).
- Maven/pom parsing: entity references and numeric character references are assembled instead of truncating the value, CDATA sections are kept, `<exclusions>` no longer renames the enclosing dependency, and a coordinate the parser cannot read as written is skipped rather than reported under a made-up value (#394).
- Lockfile resolution matches the requirement declared in the manifest, so `serde = "~1.1"` no longer reports `1.2.0` as installed (#392).
- Rust dependency set refreshed (`tokio`, `clap`, `serde`, `quick-xml` 0.42, …) plus `actions/setup-node` v7 and `CodSpeedHQ/action` v5.

Checks run locally on `depsy-lsp`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (847 passed), `cargo test --test integration_test` (8 passed). Same fmt/clippy on `depsy-zed`.

Tag `v2.0.2` is not created here — push it once this is merged to trigger the release workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v2.0.2 release: cuts the changelog and bumps the version in `depsy-lsp`, `depsy-zed`, and the extension manifest.

**What ships in 2.0.2:**
- Cargo target-specific dependency sections are parsed, and crates declared in multiple sections are no longer double-counted.
- Maven/pom parsing now assembles entity references, keeps CDATA, respects `<exclusions>`, and skips unreadable coordinates.
- Lockfile resolution matches the manifest requirement, so `serde = "~1.1"` no longer reports `1.2.0` as installed.
- Rust dependencies refreshed (`tokio`, `clap`, `serde`, `quick-xml`) plus CI actions updated.

The `v2.0.2` tag is not created here; push it after this merges to trigger the release workflow.

<sup>Written for commit 231ecc331df48c2b82bc042fdff52f8f655ae2d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mpiton/zed-depsy/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 2.0.2.
  * Updated the documented version across the project.
  * Added changelog details and release comparison links for version 2.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->